### PR TITLE
Fe feat/components header

### DIFF
--- a/client/src/common/header/Header.styled.tsx
+++ b/client/src/common/header/Header.styled.tsx
@@ -5,13 +5,18 @@ export const HeaderContainer = tw.div`
   flex
   justify-between
   items-center
+  px-6
+  py-4
 `;
 
 export const NavList = tw.ul`
-flex gap-5
-items-center
+  flex gap-5
+  items-center
 
-li {
-  text-9xl	
-}
+`;
+
+export const NavItem = tw.li<{ currenttab: number; idx: number }>`
+  font-bold
+  cursor-pointer
+  ${prop => (prop.currenttab === prop.idx ? `text-deepgreen` : `text-deepgray`)}
 `;

--- a/client/src/common/header/Header.tsx
+++ b/client/src/common/header/Header.tsx
@@ -1,42 +1,10 @@
-// import { ReactComponent as Github } from '../../assets/github.svg';
-// import { ReactComponent as Notion } from '../../assets/notion.svg';
-// import { Container, TopContainer, Text } from './Header.styled';
-
-// export default function Footer() {
-//   return (
-//     <Container>
-//       <TopContainer>
-//         <div className="flex items-center">
-//           <Notion />
-//           <a href="https://www.notion.so/codestates/18-e6a765fcd5f84d6ba6ef261cd16a69cd">
-//             <Text>노션</Text>
-//           </a>
-//         </div>
-
-//         <div className="flex items-center">
-//           <Github />
-//           <a href="https://github.com/codestates-seb/seb44_main_018">
-//             <Text>깃허브</Text>
-//           </a>
-//         </div>
-
-//         <div className="pt-[3px] flex gap-2">
-//           <Text>개인정보처리방침</Text>
-//           <Text>약관</Text>
-//           <Text>연락처</Text>
-//         </div>
-//       </TopContainer>
-//       <Text>@2023 Petgram from 색도18</Text>
-//     </Container>
-//   );
-// }
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { ReactComponent as Paw } from '../../assets/paw.svg';
 import Path from '../../routers/paths';
 import Button from '../button/Button';
 import Profile from '../profile/Profile';
-import { HeaderContainer, NavList } from './Header.styled';
+import { HeaderContainer, NavItem, NavList } from './Header.styled';
 
 interface HeaderProps {
   isloginuser: string;
@@ -44,6 +12,16 @@ interface HeaderProps {
 
 export default function Header({ isloginuser }: HeaderProps) {
   const navigate = useNavigate();
+  const [currentTab, setCurrentTab] = useState(0);
+  const selectTabHandler = (index: number) => {
+    setCurrentTab(index);
+  };
+
+  const tabs = [
+    { name: '홈', link: Path.Home },
+    { name: '산책', link: Path.WalkMate },
+    { name: '포스트', link: Path.FeedPosting },
+  ];
 
   return (
     <>
@@ -55,25 +33,22 @@ export default function Header({ isloginuser }: HeaderProps) {
             </Link>
           </div>
           <nav>
-            <NavList
-              onClick={e => {
-                console.log(e);
-              }}>
-              <li>
-                <Link to={Path.Home}>홈</Link>
-              </li>
-              <li>
-                <Link to={Path.WalkMate}>산책</Link>
-              </li>
-              <li>
-                <Link to={Path.FeedPosting}>포스트</Link>
-              </li>
+            <NavList>
+              {tabs.map((tab, index) => (
+                <NavItem
+                  key={index}
+                  onClick={() => selectTabHandler(index)}
+                  currenttab={currentTab}
+                  idx={index}>
+                  <Link to={tab.link}>{tab.name}</Link>
+                </NavItem>
+              ))}
               <li>
                 <Link to={Path.MyPage}>
                   <Profile
                     size="md"
                     url="https://huchu.link/MZFVNjh"
-                    isgreen="true"
+                    isgreen="false"
                   />
                 </Link>
               </li>

--- a/client/src/common/profile/Profile.styled.tsx
+++ b/client/src/common/profile/Profile.styled.tsx
@@ -10,9 +10,10 @@ export const ProfileImage = tw.img<ProfileContainerProps>`
    ${prop => prop.size === 'md' && `w-[52px] h-[52px]`}
    ${prop => prop.size === 'sm' && `w-[32px] h-[32px]`}
    ${prop =>
-     prop.isgreen === 'true' ? `border-defaulttext` : `border-lightgray`}
+     prop.isgreen === 'true'
+       ? `border-2 border-deepgreen`
+       : `border border-lightgray`}
     rounded-full
-    border
+    
     object-cover
-    bg-deepgreen
 `;


### PR DESCRIPTION
### What is this PR?

- Header 컴포넌트 생성
- 이슈 close
    - close #50  
  

### TODO
- [x] 로그인한 유저와, 게스트 유저에게 보이는 Header의 성능은 각자 다르다. 
- [x] 홈`/home` , 산책 `/walkmate`, 포스트 `/feed-posting` 으로 router를 설정한다. 
- [x] user profile은 `/my-page`로 routing 한다.
- [x] 해당 페이지에 있다면, 해당하는 Nav를 `#69B783` 색으로 강조한다.
- [x] 로그인 버튼 클릭시 `/`로 이동한다.
- [x] 로그아웃 버튼 클릭시 서버와 논의하여 로그아웃 방식을 결정한다.

### Screenshot
<img width="1434" alt="스크린샷 7" src="https://github.com/codestates-seb/seb44_main_018/assets/89183947/a81ca4ab-00e2-4dc4-b7ba-2f3fdbce32b3">

