### PR TITLE
Feat: 주소 Select 컴포넌트 생성

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,31 +1,10 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import Popup from './common/popup/Popup';
+import Select from './common/select/Select';
+
 function App() {
-  const navigate = useNavigate();
-  const [isOpened, setIsOpened] = useState(true);
-  const handleClose = () => {
-    setIsOpened(false);
-  };
-  const handleNavigate = () => {
-    setIsOpened(false);
-    navigate('/123');
-  };
   return (
-    <>
-      <div className="w-screen h-screen flex justify-center items-center bg-slate"></div>
-      {isOpened && (
-        <Popup
-          title="회원가입을 하셔야 사용합니다"
-          handler={[handleClose, handleNavigate]}
-          btnsize={['md', 'md']}
-          countbtn={2}
-          buttontext={['닫기', '확인']}
-          isgreen={['true', 'false']}
-          popupcontrol={handleClose}
-        />
-      )}
-    </>
+    <div>
+      <Select direction={'column'} size={'lg'} />
+    </div>
   );
 }
 

--- a/client/src/api/queryfn.ts
+++ b/client/src/api/queryfn.ts
@@ -1,0 +1,20 @@
+// eslint-disable-next-line import/named
+import axios, { isAxiosError, AxiosResponse } from 'axios';
+
+// 쿼리함수를 관리합니다.
+
+//시군구 정보 가져오기
+export const getLocal = async (pattern: string) => {
+  const URL =
+    'https://grpc-proxy-server-mkvo6j4wsq-du.a.run.app/v1/regcodes?regcode_pattern=';
+  try {
+    const result = await axios.get(`${URL}${pattern}`);
+    return result.data;
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const errMessage = (error.response as AxiosResponse<{ message: string }>)
+        ?.data.message;
+      return errMessage;
+    }
+  }
+};

--- a/client/src/common/button/Button.tsx
+++ b/client/src/common/button/Button.tsx
@@ -1,8 +1,8 @@
-import { BooleanStr, BtnSize, Handler } from '../../types/buttonType';
+import { BooleanStr, Size, Handler } from '../../types/propType';
 import { Btn } from './button.styled';
 
 interface Prop {
-  size: BtnSize; //lg, md, sm
+  size: Size; //lg, md, sm
   text: string;
   isgreen: BooleanStr;
   handler: Handler;

--- a/client/src/common/button/button.styled.tsx
+++ b/client/src/common/button/button.styled.tsx
@@ -1,9 +1,9 @@
 import tw from 'tailwind-styled-components';
-import { BooleanStr, BtnSize } from '../../types/buttonType';
+import { BooleanStr, Size } from '../../types/propType';
 
 interface BtnProp {
   isgreen: BooleanStr;
-  size: BtnSize;
+  size: Size;
 }
 
 export const Btn = tw.button<BtnProp>`
@@ -11,7 +11,7 @@ export const Btn = tw.button<BtnProp>`
   ${prop => (prop.isgreen === 'true' ? `text-white` : 'text-darkgreen')}
   ${prop => prop.size === 'lg' && 'w-[320px] max-sm:w-[220px]'}
   ${prop => prop.size === 'md' && 'w-[200px] max-sm:w-[120px]'}
-  ${prop => prop.size === 'sm' && 'w-[123px] max-sm:w-[80px]'}
+  ${prop => prop.size === 'sm' && 'w-[120px] max-sm:w-[80px]'}
   h-[50px]
   text-base
   rounded-2xl

--- a/client/src/common/popup/Popup.tsx
+++ b/client/src/common/popup/Popup.tsx
@@ -1,4 +1,4 @@
-import { BooleanStr, BtnSize, Handler } from '../../types/buttonType';
+import { BooleanStr, Size, Handler } from '../../types/propType';
 import Button from '../button/Button';
 import { PopupBackGround, PopupBox, Title, ButtonBox } from './popup.styled';
 
@@ -6,7 +6,7 @@ interface Prop {
   title: string;
   handler: Handler[];
   isgreen: BooleanStr[];
-  btnsize: BtnSize[];
+  btnsize: Size[];
   buttontext: string[];
   countbtn: 1 | 2;
   popupcontrol: Handler;

--- a/client/src/common/select/Select.tsx
+++ b/client/src/common/select/Select.tsx
@@ -1,0 +1,102 @@
+import { useState, useRef } from 'react';
+import useZipCode from '../../hook/useZipCode';
+import { Size } from '../../types/propType';
+import { changeCityCode, changeCountryCode } from '../../util/changezip';
+import { SelectContainer, SelectInput } from './select.styled';
+
+interface Prop {
+  size: Size;
+  direction: 'row' | 'column';
+}
+
+const BASE_PATTERN = '*00000000';
+
+export default function SelectComponent({ size, direction }: Prop) {
+  //state
+  const [countryCode, setCountryCode] = useState<undefined | string>(undefined);
+  const [cityCode, setCityCode] = useState<undefined | string>(undefined);
+
+  // 실제 서버에 보낼 주소
+  const [zipNameCountry, setZipNameCountry] = useState('');
+  const [zipNameCity, setZipNameCity] = useState('');
+  const [zipNameVillage, setZipNameVillage] = useState('');
+  const zipRef = useRef('');
+  //  주소 저장
+  zipRef.current = `${zipNameCountry} ${zipNameCity} ${zipNameVillage}`;
+
+  // hook 사용하기
+  const { data: counrtyData } = useZipCode({
+    zipPattern: BASE_PATTERN,
+  });
+  const { data: cityData } = useZipCode({
+    zipPattern: countryCode as string,
+    stoped: true,
+    key: countryCode,
+  });
+  const { data: villageData } = useZipCode({
+    zipPattern: cityCode as string,
+    stoped: true,
+    key: cityCode,
+  });
+
+  return (
+    <SelectContainer direction={direction}>
+      <SelectInput
+        name="country"
+        id="country"
+        selectsize={size}
+        direction={direction}
+        onChange={e => {
+          const valueArr = e.target.value.split(' ');
+          setCountryCode(changeCountryCode(valueArr[0]));
+          setZipNameCountry(valueArr[1]);
+          setZipNameCity('');
+          setZipNameVillage('');
+        }}>
+        {counrtyData &&
+          counrtyData?.regcodes.map(({ code, name }) => (
+            <option key={code} value={`${code} ${name}`}>
+              {name}
+            </option>
+          ))}
+      </SelectInput>
+
+      <SelectInput
+        name="city"
+        selectsize={size}
+        direction={direction}
+        id="city"
+        onChange={e => {
+          const valueArr = e.target.value.split(' ');
+          setCityCode(changeCityCode(valueArr[0]));
+          setZipNameCity(valueArr[1]);
+          setZipNameVillage('');
+        }}>
+        <option>선택</option>
+        {cityData &&
+          cityData?.regcodes.slice(1).map(({ code, name }) => (
+            <option key={code} value={`${code} ${name.split(' ')[1]}`}>
+              {name.split(' ')[1]}
+            </option>
+          ))}
+      </SelectInput>
+
+      <SelectInput
+        name="city"
+        id="city"
+        selectsize={size}
+        direction={direction}
+        onChange={e => {
+          setZipNameVillage(e.target.value);
+        }}>
+        <option>선택</option>
+        {villageData &&
+          villageData?.regcodes.slice(1).map(({ code, name }) => (
+            <option key={code} value={name.split(' ')[2]}>
+              {name.split(' ')[2]}
+            </option>
+          ))}
+      </SelectInput>
+    </SelectContainer>
+  );
+}

--- a/client/src/common/select/select.styled.tsx
+++ b/client/src/common/select/select.styled.tsx
@@ -1,0 +1,33 @@
+import tw from 'tailwind-styled-components';
+
+interface SelectProp {
+  selectsize: string;
+  direction: string;
+}
+
+export const SelectInput = tw.select<SelectProp>`
+  h-[50px]
+  outline
+  outline-[#d9d9d9]  
+  border-1
+  rounded-2xl
+  focus:outline
+  cursor-pointer
+  px-3
+  appearance-none
+  ${prop => prop.selectsize === 'lg' && 'w-[320px] max-sm:w-[220px]'}
+  ${prop => prop.selectsize === 'md' && 'w-[200px] max-sm:w-[120px]'}
+  ${prop => prop.selectsize === 'sm' && 'w-[120px] max-sm:w-[80px]'}
+  ${prop => (prop.direction === 'row' ? 'mr-7' : 'mb-7')}
+`;
+
+interface SelectDivProp {
+  direction: 'row' | 'column';
+}
+
+export const SelectContainer = tw.div<SelectDivProp>`
+    flex
+    ${prop => (prop.direction === 'row' ? 'flex-row' : 'flex-col')}
+    justify-center
+    items-center
+`;

--- a/client/src/hook/useZipCode.tsx
+++ b/client/src/hook/useZipCode.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLocal } from '../api/queryfn';
+
+export interface Record {
+  code: string;
+  name: string;
+}
+export interface getData {
+  regcodes: Record[];
+}
+interface Prop {
+  key?: string;
+  stoped?: boolean;
+  zipPattern: string;
+}
+
+const useZipCode = ({ key, stoped, zipPattern }: Prop) => {
+  const { data, isLoading } = useQuery<getData>({
+    queryKey: key ? ['country', key] : ['country'],
+    queryFn: () => getLocal(zipPattern),
+    enabled: stoped ? !!zipPattern : true,
+    staleTime: 1000 * 60 * 60,
+    cacheTime: 1000 * 60 * 60,
+  });
+  return { data, isLoading };
+};
+
+export default useZipCode;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,13 +1,17 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
 import App from './App.tsx';
 import './index.css';
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <QueryClientProvider client={queryClient}>
       <App />
-    </BrowserRouter>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/client/src/types/propType.tsx
+++ b/client/src/types/propType.tsx
@@ -1,3 +1,3 @@
 export type Handler = () => void;
 export type BooleanStr = 'true' | 'false';
-export type BtnSize = 'sm' | 'md' | 'lg';
+export type Size = 'sm' | 'md' | 'lg';

--- a/client/src/util/changezip.ts
+++ b/client/src/util/changezip.ts
@@ -1,0 +1,8 @@
+export const changeCountryCode = (code: string) => {
+  const pattern = /(\d{2})(\d{4})(\d+)/;
+  return code.replace(pattern, '$1*$200');
+};
+export const changeCityCode = (code: string) => {
+  const pattern = /(\d{4})(\d+)/;
+  return code.replace(pattern, '$1*');
+};


### PR DESCRIPTION
What is this PR?
- [주소 api](https://juso.dev/docs/reg-code-api/)를 react-query를 활용해서 가지고 옵니다.
- useQuery를 활용해서 순차적 api 로딩을 구현했습니다.
- 이슈 Close 
   - #44  
- prop은 다음과 같습니다.
<img width="196" alt="image" src="https://github.com/codestates-seb/seb44_main_018/assets/57277708/c8d04b73-85b8-488a-a6a5-0b0a2cfc59df">

- 서버로 보내는 값은 `zipRef.current에 저장하고 있습니다. 이를 활용하셔서 값을 보내시면 되겠습니다!`
  
Todo
- [x] /info, /walkmate 페이지에서 활용이 되어야 한다.
 - [x] select, option tag를 활용해서 구현합니다. [링크](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/select)
 - [x] 대한민국 법정동 [API](https://juso.dev/docs/reg-code-api/)를 활용합니다. API
 - [x] 시,군,구 순차적으로 선택이 되도록 연동해야 합니다.
 - [x] Prop은 width와 flexdirection을 받아야 합니다. 이는 사용되는 페이지에서 배치가 달라지기 때문입니다.
 - [x] 특별시, 도 부분에서는 기본 값이 서울특별시이고 이외의 시,군,구 선택은 기본 값이 '선택'입니다.