### PR TITLE
Feat: Info Page 컴포넌트 완성

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,7 +10,7 @@ function App() {
     <>
       {!(matchHome || matchInfo) && <Header isloginuser="true" />}
       <Outlet />
-      <Footer />
+      {!(matchHome || matchInfo) && <Footer />}
     </>
   );
 }

--- a/client/src/common/input/Input.styled.tsx
+++ b/client/src/common/input/Input.styled.tsx
@@ -9,6 +9,11 @@ type ErrorMessage = {
     | undefined;
 };
 
+export const FormContainer = tw.div`
+  pt-20
+  pb-10
+`;
+
 export const InputContainer = tw.div`
   w-80
   relative
@@ -16,8 +21,9 @@ export const InputContainer = tw.div`
 
 export const Label = tw.label`
   block
-  font-extrabold
+  font-bold
   text-defaulttext
+  mb-1
 `;
 
 export const InputText = tw.input<ErrorMessage>`
@@ -27,7 +33,7 @@ export const InputText = tw.input<ErrorMessage>`
   border
   rounded-[10px]
 
-  ${prop => prop.error === undefined && `border-deepgray`}
+  ${prop => prop.error === undefined && `border-lightgray`}
   ${prop => typeof prop.error === 'string' && `border-[#FF7B7B]`}
 `;
 

--- a/client/src/common/select/select.styled.tsx
+++ b/client/src/common/select/select.styled.tsx
@@ -18,7 +18,7 @@ export const SelectInput = tw.select<SelectProp>`
   ${prop => prop.selectsize === 'lg' && 'w-[320px] max-sm:w-[220px]'}
   ${prop => prop.selectsize === 'md' && 'w-[200px] max-sm:w-[120px]'}
   ${prop => prop.selectsize === 'sm' && 'w-[120px] max-sm:w-[80px]'}
-  ${prop => (prop.direction === 'row' ? 'mr-7' : 'mb-7')}
+  ${prop => (prop.direction === 'row' ? 'mr-7' : 'mb-4')}
 `;
 
 interface SelectDivProp {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,7 +5,12 @@
 
 @font-face {
   font-family: 'IBMPlexSansKR-Regular';
-  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-07@1.0/IBMPlexSansKR-Regular.woff') format('woff');
+  src: url('https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_20-07@1.0/IBMPlexSansKR-Regular.woff')
+    format('woff');
   font-weight: normal;
   font-style: normal;
+}
+
+body {
+  background-color: #fafafa;
 }

--- a/client/src/pages/info/Info.styled.tsx
+++ b/client/src/pages/info/Info.styled.tsx
@@ -1,0 +1,28 @@
+import tw from 'tailwind-styled-components';
+
+export const InfoForm = tw.form`
+  flex
+  flex-col
+  items-center
+  gap-7
+`;
+
+export const ConfirmButton = tw.button`
+  px-4
+  py-3
+  bg-deepgreen
+  text-white
+  text-sm
+  rounded-2xl
+  absolute
+  top-[33px]
+  right-[6px]
+
+  hover:bg-white
+  hover:text-deepgreen
+`;
+
+export const DuplicateNotice = tw.div`
+  text-[#FF7B7B]
+  text-sm
+`;

--- a/client/src/pages/info/Info.tsx
+++ b/client/src/pages/info/Info.tsx
@@ -1,15 +1,26 @@
 import { ErrorMessage } from '@hookform/error-message';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { useReadLocalStorage } from 'usehooks-ts';
+import Button from '../../common/button/Button';
 import {
   ErrorNotice,
+  FormContainer,
   InputContainer,
   InputText,
   Label,
 } from '../../common/input/Input.styled';
+import Select from '../../common/select/Select';
+import { ConfirmButton, DuplicateNotice, InfoForm } from './Info.styled';
 
 type InfoProps = {
   nickname: string;
+  name: string;
+  email: string;
+  address: string;
 };
+
 export function Component() {
   const {
     register,
@@ -17,29 +28,98 @@ export function Component() {
     formState: { errors },
   } = useForm<InfoProps>();
 
+  // TODO: submit 버튼을 눌렀을 때 회원가입이면 POST/members, 회원수정이면 PATCH/members
   const onSubmit = (data: InfoProps) => {
+    data = { ...data, address: '서울특별시 중랑구' };
     console.log(data);
+    // 서버에 받은 정보를 가지고 중복확인
+    // 중복 응답을 받은 경우, ErrorNotice로 중복된 이름입니다라는 에러보여주기
+    setNoticeMessage('중복된 닉네임입니다.');
   };
 
+  /* ----------------------------- useLocalStorage ---------------------------- */
+  const accessToken = useReadLocalStorage('accessToken');
+  const navigate = useNavigate();
+  const [nickname, setNickname] = useState('');
+  const [noticeMessage, setNoticeMessage] = useState('');
+  // 중복확인이 체크되었을때만 submit이 이뤄져야 한다.
+
+  // 비회원 로그인이 직접적으로 '/info'로 접근했을 때 확인해야 함
+  // useEffect(() => {
+  //   if (!accessToken) {
+  //     navigate('/');
+  //   }
+  // }, [accessToken, navigate]);
+
+  // login with kakao 눌렀을 때 ->
+  // 백엔드에선 해당 이메일로 멤버인지 아닌지 확인하고
+  // 없으면 추가정보로 리다이렉트
+  // 회원이라면 accessToken과 함께 '/home'으로 리다이렉트
+
+  // TODO: 서버에서 받아온 사용자 기본 정보로 이름과 이메일 작성
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <InputContainer>
-        <Label htmlFor="nickname">닉네임</Label>
-        <InputText
-          id="nickname"
-          {...register('nickname', {
-            required: '텍스트 필수입니다.',
-          })}
-          error={errors.nickname?.message}
-        />
-        <ErrorMessage
-          errors={errors}
-          name="nickname"
-          render={({ message }) => <ErrorNotice>{message}</ErrorNotice>}
-        />
-      </InputContainer>
-      <input type="submit" />
-    </form>
+    <FormContainer>
+      <InfoForm onSubmit={handleSubmit(onSubmit)}>
+        {/* 이름 */}
+        <InputContainer>
+          <Label htmlFor="name">이름</Label>
+          <InputText
+            id="nickname"
+            {...register('name')}
+            value="이재린"
+            readOnly
+          />
+        </InputContainer>
+
+        {/* 닉네임*/}
+        <InputContainer>
+          <Label htmlFor="nickname">닉네임</Label>
+          <InputText
+            id="nickname"
+            {...register('nickname', {
+              required: '텍스트 필수입니다.',
+              pattern: {
+                value: /^(?!.*\s)[\p{L}\p{N}]+$/u,
+                message: '공백과 특수기호를 제거해주세요 ;)',
+              },
+              maxLength: {
+                value: 10,
+                message: '10자 이내로 작성해주세요 ;)',
+              },
+            })}
+            error={errors.nickname?.message}
+          />
+          {noticeMessage !== '' && (
+            <DuplicateNotice>{noticeMessage}</DuplicateNotice>
+          )}
+          <ErrorMessage
+            errors={errors}
+            name="nickname"
+            render={({ message }) => <ErrorNotice>{message}</ErrorNotice>}
+          />
+          <ConfirmButton>중복확인</ConfirmButton>
+        </InputContainer>
+
+        {/* 이메일 */}
+        <InputContainer>
+          <Label htmlFor="email">이메일</Label>
+          <InputText
+            id="email"
+            {...register('email')}
+            value="jrlee_0922@naver.com"
+            readOnly
+          />
+        </InputContainer>
+
+        {/* 주소 */}
+        <div>
+          <Label>주소</Label>
+          <Select size="lg" direction="column" />
+        </div>
+        <Button size="lg" text="회원가입" isgreen="true" />
+      </InfoForm>
+    </FormContainer>
   );
 }
 


### PR DESCRIPTION
### What is this PR?
- Info 페이지 컴포넌트 구현
- 
- 이슈 close
    - close #23 
  

### TODO

- [x] 최초 Oauth 로그인 시, `이름`, `이메일` 인풋의 `value` 속성을 채우고 수정하지 못하게 `readOnly`로 설정한다.
- [x] 닉네임의 placeholder는 `공백제외 10자 이내로 입력해주세요.` 로 채워준다.
- [x] 중복확인 버튼을 생성한다.
  - [x] 닉네임 input의 오른쪽에 위치한다 `position: absolute`
  - [x] 버튼 디자인은 사진 내용과 유사하게 제작한다.
  - [x] <img width="92" alt="스크린샷 2023-07-03 오후 3 44 05" src="https://github.com/codestates-seb/seb44_main_018/assets/82816029/48a1d479-2003-4aa9-9cf9-60cb8ffeea6d">

- [ ] 유저가 닉네임 input에 아무것도 입력하지 않았을 때는 중복확인 버튼을 `disabled`로 설정한다.
  - [x] 👉🏻 중복확인 버튼을 클릭했을 때 경고메세지가 나오도록 구현하였습니다. 
- [x] 입력 후, 버튼을 클릭하면 유효성검사를 진행한다.


### Screenshot
<img width="1440" alt="스크린샷" src="https://github.com/codestates-seb/seb44_main_018/assets/89183947/fe6cbbf7-136a-453f-9262-0cc37829b0f7">

