### PR TITLE
Fix&Style: FeedPosting 컴포넌트 스타일 수정 및 컴포넌트 조건부 렌더링 추가

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,14 +7,21 @@ function App() {
   const matchInfo = useMatch('/info'); //object || null
   const matchInfoEditing = useMatch('/info/:userId'); //object || null
   const matchFeed = useMatch('/home');
+  const matchFeedPosting = useMatch('/feed-posting');
 
   return (
     <>
-      {!(matchHome || matchInfo || matchInfoEditing) && (
+      {!(matchHome || matchInfo || matchInfoEditing || matchFeedPosting) && (
         <Header isloginuser="true" />
       )}
       <Outlet />
-      {!(matchHome || matchInfo || matchFeed || matchInfoEditing) && <Footer />}
+      {!(
+        matchHome ||
+        matchInfo ||
+        matchFeed ||
+        matchInfoEditing ||
+        matchFeedPosting
+      ) && <Footer />}
     </>
   );
 }

--- a/client/src/common/popup/popup.styled.tsx
+++ b/client/src/common/popup/popup.styled.tsx
@@ -16,11 +16,10 @@ export const PopupBackGround = tw.div`
     w-full
     h-full
     flex
-    justify-center 
+    justify-center
     items-center
-    z-200
-    bg-zinc-900
-    opacity-80
+    z-[9999]
+    bg-zinc-900/75
 `;
 
 export const PopupBox = tw.div`
@@ -36,6 +35,10 @@ export const PopupBox = tw.div`
     max-sm:w-3/4
     w-1/3
     border
+    absolute
+    top-[50%]
+    left-[50%]
+    transform -translate-x-1/2 -translate-y-1/2
 `;
 
 export const Title = tw.h1`

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { ReactComponent as Close } from '../../../assets/button/close.svg';
@@ -23,6 +24,7 @@ import '../../../common/carousel/carousel.css';
 export default function FeedWriteCard() {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [savedFile, setSavedFile] = useState<string[]>([]);
+  const navigate = useNavigate();
 
   // const imgFile = new FormData();
 
@@ -54,7 +56,11 @@ export default function FeedWriteCard() {
 
       <div className="w-screen h-screen bg-zinc-900/70  absolute flex items-center justify-center">
         <Container>
-          <Close className="absolute right-6 top-6" fill="black" />
+          <Close
+            className="absolute right-6 top-6 cursor-pointer"
+            fill="black"
+            onClick={() => navigate(-1)}
+          />
           <Wrap>
             <Title>게시물 작성</Title>
           </Wrap>


### PR DESCRIPTION
### What is this PR?
- '/feed-posting'으로 이동했을 때 header와  footer 컴포넌트가 렌더링되지 않도록 useMatch를 사용하였습니다.  
- 사진을 3장 이상 추가했을 때 나타나는 팝업의 z-index를 9999로 변경하여 가장 위에 올라올 수 있도록 수정하였습니다. 

### Screenshot

https://github.com/codestates-seb/seb44_main_018/assets/89183947/d5b91713-4867-4cb5-b8c1-034d6f4b736d

