### PR TITLE
Feat: WalkPosting 페이지 컴포넌트 구현

### DIFF
--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosResponse, isAxiosError } from 'axios';
+import axios, { isAxiosError } from 'axios';
 export interface Comment {
   id: string;
   content: string;
@@ -24,7 +24,7 @@ export const editComment = async (body: Comment) => {
   }
 };
 
-/* -------------------------------- 회원 정보 추가 -------------------------------- */
+/* -------------------------------- 회원 정보 추가 / 수정 -------------------------------- */
 export interface UserInfo {
   nickname: string;
   address: string;
@@ -35,18 +35,19 @@ export const fillUserInfo = async (body: UserInfo) => {
   const url = '';
 
   try {
-    const result = await axios.patch(url, { nickname, address });
+    const result = await axios.post(url, { nickname, address });
     return result.data;
   } catch (error) {
     if (isAxiosError(error)) {
-      const errMessage = (error.response as AxiosResponse<{ message: string }>)
-        ?.data.message;
+      const errMessage = error.message;
+      console.log(errMessage);
       return errMessage;
+    } else {
+      return error;
     }
   }
 };
 
-/* -------------------------------- 회원 정보 수정 -------------------------------- */
 export const editUserInfo = async (body: UserInfo) => {
   const { nickname, address } = body;
   const url = '';
@@ -56,9 +57,11 @@ export const editUserInfo = async (body: UserInfo) => {
     return result.data;
   } catch (error) {
     if (isAxiosError(error)) {
-      const errMessage = (error.response as AxiosResponse<{ message: string }>)
-        ?.data.message;
+      const errMessage = error.message;
+      console.log(errMessage);
       return errMessage;
+    } else {
+      return error;
     }
   }
 };
@@ -69,6 +72,7 @@ type PostPetProp = {
   method: 'post' | 'patch';
   url: string;
 };
+
 export const postPet = async (body: PostPetProp) => {
   const { formData, method, url } = body;
 
@@ -89,6 +93,47 @@ export const postPet = async (body: PostPetProp) => {
       });
       return result.data;
     }
+  } catch (error) {
+    if (isAxiosError(error)) {
+      const errMessage = error.message;
+      console.log(errMessage);
+      return errMessage;
+    } else {
+      return error;
+    }
+  }
+};
+
+/* -------------------------------- 산책게시물 생성 -------------------------------- */
+interface FillWalkPosProp {
+  title: string;
+  content: string;
+  mapURL: string;
+  chatURL: string;
+  location: string;
+  time: string;
+  open: boolean;
+  maximum: number;
+  memberId: number;
+}
+
+export const fillWalkPost = async (payload: FillWalkPosProp) => {
+  const { title, content, mapURL, chatURL, location, time, open, maximum } =
+    payload;
+  const url = '';
+
+  try {
+    const result = await axios.post(`${url}/walkmates/${payload.memberId}`, {
+      title,
+      content,
+      mapURL,
+      chatURL,
+      location,
+      time,
+      open,
+      maximum,
+    });
+    return result.data;
   } catch (error) {
     if (isAxiosError(error)) {
       const errMessage = error.message;

--- a/client/src/common/input/Input.styled.tsx
+++ b/client/src/common/input/Input.styled.tsx
@@ -21,7 +21,7 @@ export const InputContainer = tw.div`
   w-[320px] max-sm:w-[220px]
   max-sm:flex
   max-sm:flex-col
-  max-sm:items-center
+  
 `;
 
 export const Label = tw.label`

--- a/client/src/pages/walkPosting/WalkPosting.styled.tsx
+++ b/client/src/pages/walkPosting/WalkPosting.styled.tsx
@@ -1,0 +1,7 @@
+import tw from 'tailwind-styled-components';
+export const PostForm = tw.form`
+  flex
+  flex-col
+  items-center
+  gap-7
+`;

--- a/client/src/pages/walkPosting/WalkPosting.tsx
+++ b/client/src/pages/walkPosting/WalkPosting.tsx
@@ -1,5 +1,175 @@
+import { ErrorMessage } from '@hookform/error-message';
+import { useMutation } from '@tanstack/react-query';
+import { MutableRefObject, TextareaHTMLAttributes, useRef } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { fillWalkPost } from '../../api/mutationfn';
+import { ReactComponent as Close } from '../../assets/button/close.svg';
+import Button from '../../common/button/Button';
+import {
+  ErrorNotice,
+  InputContainer,
+  InputText,
+  Label,
+} from '../../common/input/Input.styled';
+import { Textarea } from '../../components/card/feedwritecard/FeedWriteCard.styled';
+import { PostForm } from './WalkPosting.styled';
+
 export function Component() {
-  return <div>WalkPosting</div>;
+  const navigate = useNavigate();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+
+  // 산책게시물 등록 POST
+  const walkPostFillMutation = useMutation({
+    mutationFn: fillWalkPost,
+    onSuccess: () => {
+      console.log('success');
+    },
+    onError: () => {
+      console.log(errors);
+    },
+  });
+
+  const onSumbit = (data: any) => {
+    data = { ...data, mapURL: '', open: false, memberId: 1 };
+    console.log(data);
+    walkPostFillMutation.mutate(data);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-center gap-7 mt-16 mb-7">
+        <h2 className=" text-defaulttext font-[800] text-2xl">
+          산책 메이트 글쓰기
+        </h2>
+        <Close
+          className=" stroke-defaulttext fill-defaulttext w-6 h-6 cursor-pointer"
+          onClick={() => navigate('/walkmate')}
+        />
+      </div>
+
+      <PostForm onSubmit={handleSubmit(onSumbit)}>
+        {/* 제목 */}
+        <InputContainer>
+          <Label htmlFor="title">제목</Label>
+          <InputText
+            id="title"
+            {...register('title', {
+              required: '텍스트 필수입니다.',
+              maxLength: {
+                value: 20,
+                message: '20자 이내로 작성해주세요 ;)',
+              },
+            })}
+            error={errors.title?.message}
+          />
+          <ErrorMessage
+            errors={errors}
+            name="title"
+            render={({ message }) => <ErrorNotice>{message}</ErrorNotice>}
+          />
+        </InputContainer>
+
+        {/* 날짜 */}
+        <InputContainer>
+          <Label htmlFor="time">날짜를 선택해주세요</Label>
+          <InputText
+            id="time"
+            className=" cursor-pointer"
+            type="datetime-local"
+            {...register('time', {
+              required: '날짜도 필수입니다.',
+              maxLength: {
+                value: 20,
+                message: '20자 이내로 작성해주세요 ;)',
+              },
+            })}
+            error={errors.time?.message}
+          />
+          <ErrorMessage
+            errors={errors}
+            name="time"
+            render={({ message }) => <ErrorNotice>{message}</ErrorNotice>}
+          />
+        </InputContainer>
+
+        {/* 장소 */}
+        <InputContainer>
+          <Label htmlFor="location">산책 장소를 알려주세요</Label>
+          <InputText
+            className=" cursor-pointer"
+            id="location"
+            type="text"
+            readOnly
+            value="의정부시 의정부동 8-51 야쿠르트"
+            onClick={() => console.log('his')}
+            {...register('location', {
+              required: '장소를 선택해주세요!',
+            })}
+            error={errors.location?.message}
+          />
+          <ErrorMessage
+            errors={errors}
+            name="location"
+            render={({ message }) => <ErrorNotice>{message}</ErrorNotice>}
+          />
+        </InputContainer>
+
+        {/* 오픈채팅 url */}
+        <InputContainer>
+          <Label htmlFor="chatURL">오픈채팅방 링크</Label>
+          <InputText
+            id="chatURL"
+            type="text"
+            placeholder="(필수X)채팅방 링크가 있다면 입력해주세요:) "
+            {...register('chatURL')}
+            error={errors.chatURL?.message}
+          />
+          <ErrorMessage
+            errors={errors}
+            name="chatURL"
+            render={({ message }) => <ErrorNotice>{message}</ErrorNotice>}
+          />
+        </InputContainer>
+
+        {/* 산책 마리수 */}
+        <InputContainer>
+          <Label htmlFor="maximum">산책 친구들은 몇 마리면 좋을까요?</Label>
+          <InputText
+            id="maximum"
+            type="number"
+            {...register('maximum', {
+              required: '필수',
+              min: {
+                value: 1,
+                message: '1마리 이상이어야해요!',
+              },
+            })}
+            error={errors.maximum?.message}
+          />
+          <ErrorMessage
+            errors={errors}
+            name="maximum"
+            render={({ message }) => <ErrorNotice>{message}</ErrorNotice>}
+          />
+        </InputContainer>
+
+        {/* 텍스트 입력창 */}
+        <Textarea
+          placeholder="글을 작성해주세요"
+          {...register('content', {
+            maxLength: 300,
+          })}
+        />
+
+        <Button size="lg" text="게시물 작성" isgreen="true" />
+      </PostForm>
+    </div>
+  );
 }
 
 Component.displayName = 'WalkPosting';


### PR DESCRIPTION
### What is this PR?
- close
  - close #40
 
### TODO
- [ ] 산책 페이지`/walkmate`에서 +버튼을 클릭하면 산책 글쓰기 페이지로 이동한다. 
- [x] 작성해야할 입력 폼은 react-hook-form을 사용해서 구현한다.
- [x] 필요한 input은 총 5개이며, 오픈채팅방 링크는 필수적으로 받지 않아도 된다. (나머지 4개는 필수)
  - [x] 제목 `<input type="text" />` (제목은 최대 20자로 제한한다.)
  - [x] 날짜 `<input type="datetime-local"/>`
  - [ ] 장소 👉🏻 네이버 지도 API 사용
  - [x] 오픈채팅방 링크 (optional)
  - [x] 모집 인원수 `<input type="number" />`
- [x] 글 작성은 textarea를 사용해서 구현한다. 
- [x] 작성이 모두 완료되고 난 후 '게시물작성'버튼을 클릭하면 서버에 body에 아래와 같은 형식으로`POST`요청을 보낸다. 
```json
{
  "title": "마곡동 산책해요",
  "content": "제 강아지는 귀여워요",
  "mapURL": "~~~~.232.23232,545.454345",
  "chatURL": "~kakaopenchat.23234.url",
  "location": "서울시 강서구 마곡동",
  "time": "2023년 7월 3일 5시 30분",
  "open": true,
  "maximum": 5
}
```
- [ ] response가 정상적으로 돌아오면 작성한 게시물 `/walkmate/:postId`로 리다이렉트한다. 
- [x] x 버튼을 누르면 `/walkmate`로 리다이렉트한다. 

### Screenshot

https://github.com/codestates-seb/seb44_main_018/assets/89183947/aba074fb-c152-4ac7-8be7-31b325d46489




