### PR TITLE
Feat: 피드 페이지 구현 완료

### DIFF
--- a/client/src/components/card/sidenav/SideNav.tsx
+++ b/client/src/components/card/sidenav/SideNav.tsx
@@ -15,6 +15,7 @@ interface Prop {
   likes: number;
   like: BooleanStr;
   guesthandler: () => void;
+  toasthandler: React.Dispatch<React.SetStateAction<boolean>>;
   url: string;
 }
 
@@ -24,8 +25,9 @@ export default function SideNav({
   likes,
   like,
   guesthandler,
-}: // url,
-Prop) {
+  toasthandler,
+  url,
+}: Prop) {
   const accessToken = useReadLocalStorage<string | null>('accessToken');
   const navigate = useNavigate();
   const queryClient = useQueryClient();
@@ -51,6 +53,12 @@ Prop) {
   const handleClickComment = () => {
     if (!accessToken) return guesthandler();
     navigate(`/home/${feedid}`);
+  };
+
+  const handleClickShare = async () => {
+    await navigator.clipboard.writeText(url);
+    toasthandler(true);
+    setTimeout(() => toasthandler(false), 1500);
   };
 
   return (
@@ -79,7 +87,7 @@ Prop) {
           <Comment className="cursor-pointer ml-2" stroke="black" />
         </Wrap>
 
-        <Wrap>
+        <Wrap onClick={handleClickShare}>
           <Share className="cursor-pointer ml-2" />
         </Wrap>
       </Container>

--- a/client/src/components/toast/Toast.tsx
+++ b/client/src/components/toast/Toast.tsx
@@ -3,7 +3,7 @@ import { Container, Text } from './Toast.styled';
 
 export default function Toast() {
   return (
-    <Container>
+    <Container className="animate-smoothAppear">
       <Star />
       <Text>링크가 복사되었습니다.</Text>
     </Container>

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -12,12 +12,14 @@ import FollowingCat from '../../assets/illustration/followingcat.png';
 import Popup from '../../common/popup/Popup';
 import FeedCard from '../../components/card/feedcard/FeedCard';
 import SideNav from '../../components/card/sidenav/SideNav';
+import Toast from '../../components/toast/Toast';
 import { Feed } from '../../types/feedTypes';
 import { Container, FollowContainer, Img, Text, Button } from './Home.styled';
 
 export function Component() {
   const accessToken = useReadLocalStorage<string>('accessToken');
   const [isClicked, setIsClicked] = useState<boolean>(false);
+  const [isToastOpen, setIsToastOpen] = useState<boolean>(false);
   const [isGuestOpen, setIsGuestOpen] = useState<boolean>(false);
   const navigate = useNavigate();
 
@@ -60,6 +62,11 @@ export function Component() {
   } else if (hostFeedQuery.isSuccess && !isClicked) {
     return (
       <>
+        {isToastOpen && (
+          <div className="fixed right-8 bottom-8">
+            <Toast />
+          </div>
+        )}
         <Container>
           <Swiper
             direction={'vertical'}
@@ -86,6 +93,7 @@ export function Component() {
                     likes={img.likes}
                     like={img.isLike ? 'true' : 'false'}
                     guesthandler={() => setIsGuestOpen(true)}
+                    toasthandler={setIsToastOpen}
                     url={img.shareURL}
                   />
                 </div>
@@ -98,6 +106,11 @@ export function Component() {
   } else if (hostRandomFeedQuery.isSuccess) {
     return (
       <>
+        {isToastOpen && (
+          <div className="fixed right-8 bottom-8">
+            <Toast />
+          </div>
+        )}
         <Container>
           <Swiper
             direction={'vertical'}
@@ -125,6 +138,7 @@ export function Component() {
                       likes={img.likes}
                       like={img.isLike ? 'true' : 'false'}
                       guesthandler={() => setIsGuestOpen(true)}
+                      toasthandler={setIsToastOpen}
                       url={img.shareURL}
                     />
                   </div>
@@ -140,6 +154,11 @@ export function Component() {
       guestFeedQuery.isSuccess &&
       !accessToken && (
         <>
+          {isToastOpen && (
+            <div className="fixed right-8 bottom-8">
+              <Toast />
+            </div>
+          )}
           {isGuestOpen && (
             <Popup
               title="로그인을 해주세요."
@@ -176,6 +195,7 @@ export function Component() {
                         likes={img.likes}
                         like={img.isLike ? 'true' : 'false'}
                         guesthandler={() => setIsGuestOpen(true)}
+                        toasthandler={setIsToastOpen}
                         url={img.shareURL}
                       />
                     </div>

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -23,9 +23,15 @@ export default {
         from: { opacity: 0, transform: 'translate3d(0, 30%, 0)' },
         to: { opacity: 1, transform: 'translateZ(0)' },
       },
+      smoothAppear: {
+        '0%': { opacity: 0, transform: 'translateY(-5%)' },
+        '50%': { opacity: 1, transform: 'translateY(0)' },
+        '100%': { opacity: 0, transform: 'translateY(-5%)' },
+      },
     },
     animation: {
       fadeInUp: 'fadeInUp 0.4s ease-in-out',
+      smoothAppear: 'smoothAppear 1.5s ease-in-out',
     },
   },
   plugins: [],


### PR DESCRIPTION
### What is this PR?
- 피드 페이지 구현 완료했습니다.
- 공유버튼 클릭시, 공유 토스트 창 알림과 함께 URL이 복사되는 것을 구현했습니다.
- 이슈 close
    - close #36 

# Todo
- [x] 해당 페이지의 Router는  '/home' 입니다.
- [x] 화면에 하나의 피드 게시물만이 보이도록 합니다.
- [ ] 피드 게시물은 10개씩 가지고 옵니다.
- [ ] 무한 스크롤을 구현합니다. 

## Icon Btn
- [x] 피드는 이미지와 관련 icon Btn으로 이루어집니다. 
- [x] icon Btn은 해당 유저가 작성한 경우 수정 버튼과 삭제 버튼이 추가적으로 보여야 합니다.
- [ ] 수정 버튼 클릭시 수정 팝업창을 띄웁니다. `/feed-posting/:feedId`
- [x] 삭제 버튼을 클릭시 팝업창을 통해 최종 확인을 합니다.
- [x] 좋아요 버튼 하단에는 해당 게시물이 받은 좋아요 개수를 표기해야 합니다.
- [x] 좋아요 버튼을 이미 누른 유저에게는 좋아요 버튼의 색상이 변경되어야 합니다.
- [x] 댓글 icon 하단에는 해당 게시물에 달린 댓글의 개수를 알려주어야 합니다.
- [x] 종이비행기 아이콘을 누를시 해당 공유 링크가 클립보드에 복사 되어야 합니다. 
- [x] 클립보드 복사에 성공하면 toast를 띄웁니다.

## Feed
- [x] 이미지 게시 하단에는 유저의 프로필과 유저 아이디, 본문 내용이 있어야 합니다. 
- [x] 피드의 글은 20자만 보이게 합니다. 20 자가 넘어가면 "..."으로 표현합니다
- [x] 더보기 버튼을 클릭할 시 해당 게시물의 모든 본문 내용을 보여주어야 합니다. 이때 에니메이션을 통해 피드 이미지 위로 본문 내용을 채웁니다.
- [x] 댓글 icon을 누르면 해당 게시물과 연관된 팝업 페이지를 띄어주어야 합니다.
- [x] 피드에 사진이 여러장일 경우 [스와이퍼](https://swiperjs.com/react)를 활용해 케러셀을 구현합니다, 방향은 가로입니다.

## 부가기능
- [x] 화면 스크롤은 [스와이퍼](https://swiperjs.com/react)를 활용해서 한번에 하나의 피드로 전환되도록 합니다.

### Screenshot

https://github.com/codestates-seb/seb44_main_018/assets/82816029/1b6c8cca-94bd-4955-8bee-eaed6b0050b7

