### PR TITLE
Refactor: Header component, UserPage component 리팩토링

### DIFF
--- a/client/src/common/comment/Comment.tsx
+++ b/client/src/common/comment/Comment.tsx
@@ -1,10 +1,11 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { useReadLocalStorage } from 'usehooks-ts';
 import { deleteComment, editComment } from '../../api/mutationfn';
 import { SERVER_URL } from '../../api/url';
 import { ReactComponent as Write } from '../../assets/button/write.svg';
+import { MemberIdContext } from '../../store/Context';
 import { CommentProp } from '../../types/commentType';
 import changeTime from '../../util/changeTiem';
 import Popup from '../popup/Popup';
@@ -39,7 +40,9 @@ export default function Comment(props: CommentProp) {
     walkMatePostId,
   } = props;
 
-  const userId = useReadLocalStorage('memberId');
+  // const userId = useReadLocalStorage('memberId');
+  const userId = useContext(MemberIdContext);
+
   const accessToken = useReadLocalStorage<string | null>('accessToken');
 
   const [isEdited, setIsEdited] = useState(false);
@@ -55,8 +58,8 @@ export default function Comment(props: CommentProp) {
       id: feedCommentsId ? `${feedCommentsId}` : `${walkMateCommentId}`,
       content: newComment,
       url: feedCommentsId
-        ? `${SERVER_URL}/feeds/comments/${feedCommentsId}/${memberId}`
-        : `${SERVER_URL}/walkmates/comments/${walkMateCommentId}/${memberId}`,
+        ? `${SERVER_URL}/feeds/comments/${feedCommentsId}`
+        : `${SERVER_URL}/walkmates/comments/${walkMateCommentId}`,
       tag: feedCommentsId ? 'feed' : 'walk',
       accessToken,
     };
@@ -66,7 +69,7 @@ export default function Comment(props: CommentProp) {
   // 산책 댓글 삭제
   const handleDeleteComment = (walkMateCommentId: number | undefined) => {
     const data = {
-      url: `${SERVER_URL}/walkmates/comments/${walkMateCommentId}/${memberId}`,
+      url: `${SERVER_URL}/walkmates/comments/${walkMateCommentId}`,
       accessToken,
     };
     deleteCommentMutaion.mutate(data);

--- a/client/src/common/header/Header.tsx
+++ b/client/src/common/header/Header.tsx
@@ -15,7 +15,6 @@ export default function Header() {
   const matchPost = useMatch('/feed-posting');
   const matchMypage = useMatch('/my-page');
   const accessToken = useReadLocalStorage<string | null>('accessToken');
-  const animalParents = useReadLocalStorage<string | null>('animalParents');
   const navigate = useNavigate();
 
   const { data, isSuccess } = useQuery({
@@ -27,7 +26,6 @@ export default function Header() {
 
   const handleClick = () => {
     localStorage.removeItem('accessToken');
-    localStorage.removeItem('animalParents');
     localStorage.removeItem('refreshToken');
     navigate('/');
   };
@@ -45,7 +43,7 @@ export default function Header() {
             <NavItem active={matchHome !== null ? 'false' : 'true'}>
               <Link to={Path.Home}>홈</Link>
             </NavItem>
-            {animalParents === 'true' && (
+            {data.animalParents && (
               <NavItem active={matchWalkmate !== null ? 'false' : 'true'}>
                 <Link to={Path.WalkMate}>산책</Link>
               </NavItem>

--- a/client/src/components/notice/NoticeNoData.tsx
+++ b/client/src/components/notice/NoticeNoData.tsx
@@ -2,13 +2,19 @@ import { useNavigate } from 'react-router-dom';
 import LyingDownDog from '../../assets/illustration/lying-down-dog.png';
 import { ErrorText, HomeBtn } from '../../pages/notFound/NotFound.style';
 
-export default function NoticeNoData({ url }: { url: string }) {
+type NoticeNoDataProp = {
+  url: string;
+};
+
+export default function NoticeNoData({ url }: NoticeNoDataProp) {
   const navigate = useNavigate();
   return (
     <div className="flex flex-col items-center justify-center">
       <ErrorText>작성한 피드가 없으시군요! 게시물 등록하러 가볼까요?</ErrorText>
       <img src={LyingDownDog} className=" w-80" />
-      <HomeBtn onClick={() => navigate(`/${url}`)}>게시물 생성하러가기</HomeBtn>
+      <HomeBtn onClick={() => navigate(`/${url}`)}>
+        게시물 등록하러 가기
+      </HomeBtn>
     </div>
   );
 }

--- a/client/src/pages/myPage/MyPage.tsx
+++ b/client/src/pages/myPage/MyPage.tsx
@@ -8,6 +8,7 @@ import { SERVER_URL } from '../../api/url';
 import { ReactComponent as Setting } from '../../assets/button/setting.svg';
 import { ReactComponent as CommentListIcon } from '../../assets/comment-list.svg';
 import { ReactComponent as FeedIcon } from '../../assets/feed.svg';
+import Cat404 from '../../assets/illustration/404cat.png';
 import { ReactComponent as WalkFeedIcon } from '../../assets/walk-feed.svg';
 import Profile from '../../common/profile/Profile';
 import WalkCard from '../../components/card/walkCard/walkCard';
@@ -24,6 +25,7 @@ import { Feed } from '../../types/feedTypes';
 import { Follow, UserInfo } from '../../types/userType';
 import { WalkFeed } from '../../types/walkType';
 import changeTime from '../../util/changeTiem';
+import { ErrorText } from '../notFound/NotFound.style';
 import { CommentList } from '../walkMate/WalkMate.styled';
 import {
   Container,
@@ -311,7 +313,12 @@ export function Component() {
                   ) : (
                     <div>
                       {!commentListData?.length ? (
-                        <NoticeNoData url="walkmate" />
+                        <div className="flex flex-col items-center justify-center">
+                          <ErrorText>
+                            아직 댓글을 단 산책 게시물이 없어요.
+                          </ErrorText>
+                          <img src={Cat404} className=" w-80" />
+                        </div>
                       ) : (
                         commentListData?.map(item => (
                           <Link


### PR DESCRIPTION
### What is this PR?
- Header에서 localStorage에 저장해놓았던 animalParents으로 산책 탭 렌더링을 분기처리하던 로직을 변경하였습니다. 
- 유저 페이지 내에서 유저가 견주등록이 되어있지 않다면 검색한 유저의 산책 게시물을 볼 수 없도록 분기처리하였습니다. 