### PR TITLE
Feat: 피드 팝업페이지 부분 구현 (댓글 달기)

### DIFF
--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -208,6 +208,29 @@ export const patchFeedLike = async (body: MutationProp) => {
   return result;
 };
 
+/* -------------------------------- 피드게시물 댓글 작성  -------------------------------- */
+
+interface PostFeedCommentProp {
+  url: string;
+  token: string;
+  content: string;
+  feedId: number;
+}
+
+export const postFeedComment = async (body: PostFeedCommentProp) => {
+  const { url, token, content, feedId } = body;
+  const result = await axios.post(
+    url,
+    { content, feedId },
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+  return result;
+};
+
 /* -------------------------------- 산책게시물 생성 -------------------------------- */
 interface FillWalkPosProp {
   title: string;

--- a/client/src/common/comment/feedComment.tsx/FeedComment.styled.tsx
+++ b/client/src/common/comment/feedComment.tsx/FeedComment.styled.tsx
@@ -1,0 +1,29 @@
+import tw from 'tailwind-styled-components';
+export const Container = tw.div`
+  flex
+  flex-col
+`;
+
+export const UserBox = tw.div`
+  flex
+  items-center
+  gap-2
+`;
+
+export const UserId = tw.span`
+  font-black
+  text-defaulttext
+  text-xs
+  mr-1
+`;
+
+export const Time = tw.span`
+  text-deepgray
+  text-xs
+`;
+
+export const Content = tw.span`
+  pl-10
+  text-xs
+  leading-[1.2rem]
+`;

--- a/client/src/common/comment/feedComment.tsx/FeedComment.tsx
+++ b/client/src/common/comment/feedComment.tsx/FeedComment.tsx
@@ -1,0 +1,33 @@
+import Profile from '../../profile/Profile';
+import {
+  Container,
+  UserBox,
+  UserId,
+  Time,
+  Content,
+} from './FeedComment.styled';
+
+interface Prop {
+  memberid: number;
+  nickname: string;
+  userimg: string;
+  content: string;
+}
+
+export default function FeedComment({
+  // memberid,
+  nickname,
+  userimg,
+  content,
+}: Prop) {
+  return (
+    <Container>
+      <UserBox>
+        <Profile size="sm" isgreen="false" url={userimg} />
+        <UserId>{nickname}</UserId>
+        <Time>몇시간전</Time>
+      </UserBox>
+      <Content>{content}</Content>
+    </Container>
+  );
+}

--- a/client/src/common/input/feedInput/FeedInput.styled.tsx
+++ b/client/src/common/input/feedInput/FeedInput.styled.tsx
@@ -1,0 +1,25 @@
+import tw from 'tailwind-styled-components';
+
+export const Container = tw.div`
+  w-full
+  relative
+`;
+
+export const Input = tw.textarea`
+  border-[1.5px]
+  border-lightgray
+  resize-none
+  w-full
+  h-10
+  rounded-[10px]
+  px-3
+  text-xs
+  py-3
+  pr-10
+`;
+
+export const CommentBtn = tw.button`
+  absolute
+  bottom-3
+  right-2
+`;

--- a/client/src/common/input/feedInput/FeedInput.tsx
+++ b/client/src/common/input/feedInput/FeedInput.tsx
@@ -1,0 +1,48 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { useRef } from 'react';
+import { useReadLocalStorage } from 'usehooks-ts';
+import { postFeedComment } from '../../../api/mutationfn';
+import { SERVER_URL } from '../../../api/url';
+import { ReactComponent as Write } from '../../../assets/button/write.svg';
+import { Container, Input, CommentBtn } from './FeedInput.styled';
+
+interface Prop {
+  feedid: number;
+}
+
+export default function FeedInput({ feedid }: Prop) {
+  const accessToken = useReadLocalStorage('accessToken');
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+  const queryClient = useQueryClient();
+  const { mutate } = useMutation({
+    mutationFn: postFeedComment,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: ['feedPopUp', feedid],
+      });
+    },
+  });
+
+  const handleClick = () => {
+    if (inputRef.current) {
+      if (inputRef.current.value === '') return alert('공백안된다');
+      const data = {
+        url: `${SERVER_URL}/feeds/comments`,
+        token: accessToken as string,
+        content: inputRef.current.value,
+        feedId: feedid,
+      };
+      mutate(data);
+      inputRef.current.value = '';
+    }
+  };
+
+  return (
+    <Container>
+      <Input ref={inputRef} />
+      <CommentBtn onClick={handleClick}>
+        <Write />
+      </CommentBtn>
+    </Container>
+  );
+}

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -34,6 +34,16 @@ export default function FeedWriteCard() {
   const [prevFile, setPrevFile] = useState<File[]>([]);
   /* ----------------------------- useLocalStorage ---------------------------- */
   const accessToken = useReadLocalStorage<string>('accessToken');
+
+  useEffect(() => {
+    const getBackPage = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        navigate(-1);
+      }
+    };
+    window.addEventListener('keydown', getBackPage);
+    return () => window.removeEventListener('keydown', getBackPage);
+  }, [navigate]);
 
   const { mutate, isLoading } = useMutation({
     mutationFn: feedPosting,
@@ -88,9 +98,7 @@ export default function FeedWriteCard() {
       <div
         className="w-screen h-screen bg-zinc-900/75  absolute flex items-center justify-center"
         onClick={e => {
-          if (e.target === e.currentTarget) {
-            navigate(-1);
-          }
+          if (e.target === e.currentTarget) navigate(-1);
         }}>
         <Container>
           <Close

--- a/client/src/components/card/sidenav/SideNav.styled.tsx
+++ b/client/src/components/card/sidenav/SideNav.styled.tsx
@@ -5,12 +5,14 @@ interface ContainerProp {
 }
 
 export const Container = tw.div<ContainerProp>`
-  w-16
   flex
   ${props => `flex-${props.direction}`}
   ${props => props.direction === 'row' && 'w-72'}
   ${props => props.direction === 'col' && 'gap-3'}
   items-center
+  ${props => props.direction === 'row' && 'items-start'}
+  ${props => props.direction === 'row' && 'gap-3'}
+  ${props => props.direction === 'row' && 'pt-1'}
 `;
 
 export const Wrap = tw.div`

--- a/client/src/components/card/sidenav/SideNav.tsx
+++ b/client/src/components/card/sidenav/SideNav.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useNavigate } from 'react-router-dom';
+import { useMatch, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
 import { patchFeedLike } from '../../../api/mutationfn';
 import { SERVER_URL } from '../../../api/url';
@@ -31,6 +31,7 @@ export default function SideNav({
   const accessToken = useReadLocalStorage<string | null>('accessToken');
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const feedPopUp = useMatch('/home/:feedId');
 
   const likeMutation = useMutation({
     mutationFn: patchFeedLike,
@@ -90,13 +91,32 @@ export default function SideNav({
           <Text>{likes}</Text>
         </Wrap>
 
-        <Wrap onClick={handleClickComment}>
-          <Comment className="cursor-pointer ml-2" stroke="black" />
-        </Wrap>
+        {!feedPopUp && (
+          <Wrap onClick={handleClickComment}>
+            <Comment className="cursor-pointer ml-2" stroke="black" />
+          </Wrap>
+        )}
 
         <Wrap onClick={handleClickShare}>
           <Share className="cursor-pointer ml-2" />
         </Wrap>
+
+        {/* {inperson === 'true' && (
+          <>
+            <Wrap onClick={() => navigate(`/feed-posting/${feedid}`)}>
+              <Edit className="cursor-pointer ml-2" />
+            </Wrap>
+            <Wrap>
+              <Delete
+                className="cursor-pointer ml-2"
+                onClick={() => {
+                  deletehandler();
+                  localStorage.setItem('feedId', String(feedid));
+                }}
+              />
+            </Wrap>
+          </>
+        )} */}
       </Container>
     </>
   );

--- a/client/src/components/toast/Toast.styled.tsx
+++ b/client/src/components/toast/Toast.styled.tsx
@@ -3,8 +3,6 @@ import tw from 'tailwind-styled-components';
 export const Container = tw.div`
   w-56
   p-4
-  border
-  border-lightgray
   rounded-xl
   drop-shadow-xl
   bg-deepgreen

--- a/client/src/pages/feedPopUp/FeedPopUp.styled.tsx
+++ b/client/src/pages/feedPopUp/FeedPopUp.styled.tsx
@@ -1,0 +1,53 @@
+import tw from 'tailwind-styled-components';
+
+export const Container = tw.div`
+  fixed
+  top-0
+  right-0
+  w-screen
+  h-screen
+  flex
+  justify-center
+  items-center
+  z-40
+  bg-zinc-900/75
+  z-50
+  relative
+`;
+
+export const CloseBtn = tw.button`
+  absolute
+  right-10
+  top-10
+`;
+
+export const FeedContainer = tw.div`
+  w-[48rem]
+  h-[560px]
+  bg-defaultbg
+  flex
+  p-2
+  rounded-[2rem]
+  drop-shadow-xl
+  gap-2
+`;
+
+export const RightBox = tw.div`
+  w-[22rem]
+  p-3
+  flex
+  flex-col
+  items-center
+`;
+
+export const CommentBox = tw.div`
+  w-80
+  h-[26rem]
+  overflow-scroll
+  flex
+  flex-col
+  gap-y-5
+  mb-3
+  border-b-[1.5px]
+  border-lightgray
+`;

--- a/client/src/pages/feedPopUp/FeedPopUp.tsx
+++ b/client/src/pages/feedPopUp/FeedPopUp.tsx
@@ -1,48 +1,32 @@
 import { useQuery } from '@tanstack/react-query';
-import { useParams } from 'react-router-dom';
-import tw from 'tailwind-styled-components';
+import { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
 import { getServerDataWithJwt } from '../../api/queryfn';
 import { SERVER_URL } from '../../api/url';
+import { ReactComponent as Close } from '../../assets/button/close.svg';
+import FeedComment from '../../common/comment/feedComment.tsx/FeedComment';
+import FeedInput from '../../common/input/feedInput/FeedInput';
 import FeedCard from '../../components/card/feedcard/FeedCard';
 import SideNav from '../../components/card/sidenav/SideNav';
 import LoadingComponent from '../../components/loading/LoadingComponent';
-
-const Container = tw.div`
-  fixed
-  top-0
-  right-0
-  w-screen
-  h-screen
-  flex
-  justify-center
-  items-center
-  z-40
-  bg-zinc-900/75
-  z-50
-`;
-
-const FeedContainer = tw.div`
-  w-[48rem]
-  h-[560px]
-  bg-defaultbg
-  flex
-  p-2
-  rounded-3xl
-  drop-shadow-xl
-`;
-
-const RightBox = tw.div`
-  w-96
-  h-96
-  bg-blue-400
-`;
+import Toast from '../../components/toast/Toast';
+import { Feed } from '../../types/feedTypes';
+import {
+  Container,
+  CloseBtn,
+  FeedContainer,
+  RightBox,
+  CommentBox,
+} from './FeedPopUp.styled';
 
 export function Component() {
   const accessToken = useReadLocalStorage('accessToken');
+  const navigate = useNavigate();
   const { feedId } = useParams();
-  const { data, isSuccess, isLoading } = useQuery({
-    queryKey: ['feedPopUp'],
+  const [isToastOpen, setIsToastOpen] = useState<boolean>(false);
+  const { data, isSuccess, isLoading } = useQuery<Feed>({
+    queryKey: ['feedPopUp', Number(feedId)],
     queryFn: () =>
       getServerDataWithJwt(
         `${SERVER_URL}/feeds/${feedId}`,
@@ -51,10 +35,32 @@ export function Component() {
   });
   console.log(data);
 
+  // ESC 버튼 누를 시, 이전페이지로 이동
+  useEffect(() => {
+    const getBackPage = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        navigate(-1);
+      }
+    };
+    window.addEventListener('keydown', getBackPage);
+    return () => window.removeEventListener('keydown', getBackPage);
+  }, [navigate]);
+
   if (isLoading) return <LoadingComponent />;
   if (isSuccess)
     return (
-      <Container>
+      <Container
+        onClick={e => {
+          if (e.target === e.currentTarget) navigate(-1);
+        }}>
+        {isToastOpen && (
+          <div className="fixed right-8 bottom-8">
+            <Toast />
+          </div>
+        )}
+        <CloseBtn onClick={() => navigate(-1)}>
+          <Close fill="white" />
+        </CloseBtn>
         <FeedContainer>
           <FeedCard
             memberid={data.memberInfo.memberId}
@@ -65,13 +71,28 @@ export function Component() {
           />
 
           <RightBox>
+            <CommentBox>
+              {data.feedComments !== null &&
+                Array.isArray(data.feedComments) &&
+                data.feedComments.map(comment => (
+                  <FeedComment
+                    key={comment.feedCommentsId}
+                    memberid={comment.memberInfo.memberId}
+                    nickname={comment.memberInfo.nickname}
+                    userimg={comment.memberInfo.imageURL}
+                    content={comment.content}
+                  />
+                ))}
+            </CommentBox>
             <SideNav
               feedid={data.feedId}
               direction="row"
               likes={data.likes}
               like={data.isLike ? 'true' : 'false'}
               url={data.shareURL}
+              toasthandler={setIsToastOpen}
             />
+            <FeedInput feedid={data.feedId} />
           </RightBox>
         </FeedContainer>
       </Container>

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -10,7 +10,7 @@ import { getGuestFeedList, getHostFeedList } from '../../api/queryfn';
 import { SERVER_URL } from '../../api/url';
 import FollowingCat from '../../assets/illustration/followingcat.png';
 import Popup from '../../common/popup/Popup';
-import FeedCard from '../../components/card/feedCard/FeedCard';
+import FeedCard from '../../components/card/feedcard/FeedCard';
 import SideNav from '../../components/card/sidenav/SideNav';
 import Toast from '../../components/toast/Toast';
 import { Feed } from '../../types/feedTypes';

--- a/client/src/pages/myPage/MyPage.tsx
+++ b/client/src/pages/myPage/MyPage.tsx
@@ -266,7 +266,7 @@ export function Component() {
                         {feedData?.responseList?.map(item => (
                           <Link to={`/home/${item.feedId}`} key={item.feedId}>
                             <img
-                              className="w-full h-[180px] rounded-[28px] object-cover"
+                              className="w-full h-[180px] rounded-[28px] object-cover border-2 hover:drop-shadow-lg"
                               src={item.images[0].uploadFileURL}
                             />
                           </Link>


### PR DESCRIPTION
- 피드 팝업페이지 댓글을 올릴 수 있는 기능을 구현하였습니다.
- 추후 본인게시물인지 여부에 따라 게시물을 수정 및 삭제할 수 있습니다.
- 추후 본인의 댓글인지 여부에 따라 댓글을 수정 및 삭제할 수 있습니다.

### What is this PR?

- 간략하게 구현한 기능 작성 ex) ~~ 기능 구현
- 이슈 close
    - close #38

# Todo
## Feed
- [ ] 피드 게시물은 피드 페이지의 피드와 추가로 댓글을 보여줍니다. 
- [ ] 피드 게시물의 유저 네임 혹은 유저 프로필을 클릭하면 유저 페이지로 이동합니다.

## Comment
- [ ] 댓글은 한번에 10개를 보여주며, 무한 스크롤로 구현합니다.(초기 팝업 페이지 생성시 모든 댓글을 가지고 옵니다.)
- [ ] 댓글은 유저 프로필, 유저 닉네임, 댓글 내용, 생성 시간으로 구성됩니다.
- [ ] 댓글의 유저 프로필, 유저 닉네임을 클릭하면 해당 유저페이지로 이동합니다.
- [ ] 본인이 작성한 댓글에는 수정과 삭제 버튼을 볼 수 있습니다. 
- [ ] 댓글 수정시 인풋 창이 생성됩니다. 
- [ ] 수정과 삭제는 본인이 작성한 게시물일 경우 해당 팝업 페이지에서 언제든 가능합니다.
- [ ] 유저가 계정이 없는 경우 댓글 작성 input을 비활성화 합니다.

## Button
- [x] 공통 button은 좋아요, 댓글, 링크 복사 버튼입니다.
- [ ] 게시글 작성자와 유저가 일치할시 추가로 게시글 수정 버튼과 게시글 삭제 버튼을 보여줍니다.
- [ ] #49
- [ ] 게시글 삭제 버튼 클릭시 삭제를 확인하는 팝업창을 띄우고 삭제를 진행합니다. 
- [x] 본인이 좋아요를 이미 클릭한 게시물일 경우 이를 표기해야 합니다. 
- [x] 좋아요  button 아래에는 좋아요 총 개수가 표시되어야 합니다.

## 팝업 페이지 클립보드
- [ ] 피드페이지, 팝업 페이지에서 링크공유로 복사된 url은 팝업을 구분하는 쿼리 파람이 포함되어야 합니다.
(ex. http:/copy/:feedId)
- [ ] 팝업 이외에 페이지 형식은 같습니다. 
- [x] 비로그인 유저는 오직 홈으로만 이동할 수 있습니다.  
- [x] header의 홈 버튼은 비활성화 되어 있어야 합니다.


### Screenshot
![피드팝업댓글](https://github.com/codestates-seb/seb44_main_018/assets/82816029/01bbfc4f-a5e5-444e-8089-5329929aab45)

되게 많이 구현한줄알았는데.. 이슈는 close할게 없네요..