### PR TITLE
Feat: 피드 게시물 댓글 수정 삭제 구현 완료

### DIFF
--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -231,6 +231,33 @@ export const postFeedComment = async (body: PostFeedCommentProp) => {
   return result;
 };
 
+/* -------------------------------- 피드게시물 댓글 수정  -------------------------------- */
+export const patchFeedComment = async (body: PostFeedCommentProp) => {
+  const { url, token, content, feedId } = body;
+  console.log(body);
+  const result = await axios.patch(
+    url,
+    { content, feedId },
+    {
+      headers: {
+        Authorization: token,
+      },
+    },
+  );
+  return result;
+};
+
+/* -------------------------------- 피드게시물 댓글 삭제  -------------------------------- */
+export const deleteFeedComment = async (body: MutationProp) => {
+  const { url, accessToken } = body;
+  const result = await axios.delete(url, {
+    headers: {
+      Authorization: accessToken,
+    },
+  });
+  return result;
+};
+
 /* -------------------------------- 산책게시물 생성 -------------------------------- */
 interface FillWalkPosProp {
   title: string;

--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -179,14 +179,14 @@ export const feedPosting = async (body: FeedPostingProp) => {
 /* -------------------------------- 피드게시물 삭제 -------------------------------- */
 interface DeleteFeedProp {
   url: string;
-  accessToken: string | null;
+  token: string | null;
 }
 
 export const deleteFeed = async (body: DeleteFeedProp) => {
-  const { url, accessToken } = body;
+  const { url, token } = body;
   const result = await axios.delete(url, {
     headers: {
-      Authorization: accessToken,
+      Authorization: token,
     },
   });
   return result;

--- a/client/src/common/comment/Comment.tsx
+++ b/client/src/common/comment/Comment.tsx
@@ -40,7 +40,6 @@ export default function Comment(props: CommentProp) {
     walkMatePostId,
   } = props;
 
-
   const { memberId: userId } = useContext(MemberIdContext) as State;
   const accessToken = useReadLocalStorage<string | null>('accessToken');
 

--- a/client/src/common/comment/feedComment.tsx/FeedComment.styled.tsx
+++ b/client/src/common/comment/feedComment.tsx/FeedComment.styled.tsx
@@ -14,7 +14,7 @@ export const UserId = tw.span`
   font-black
   text-defaulttext
   text-xs
-  mr-1
+  
 `;
 
 export const Time = tw.span`
@@ -26,4 +26,29 @@ export const Content = tw.span`
   pl-10
   text-xs
   leading-[1.2rem]
+`;
+
+export const EditText = tw.span`
+  text-deepgray
+  text-xs
+  cursor-pointer
+`;
+
+export const EditTextarea = tw.textarea`
+  border-[1.5px]
+  border-lightgray
+  resize-none
+  w-[17rem]
+  h-8
+  ml-10
+  text-xs
+  p-2
+  rounded-[10px]
+  pr-9
+`;
+
+export const EditBtn = tw.button`
+  absolute
+  right-4
+  bottom-2
 `;

--- a/client/src/common/comment/feedComment.tsx/FeedComment.tsx
+++ b/client/src/common/comment/feedComment.tsx/FeedComment.tsx
@@ -1,3 +1,10 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState, useRef } from 'react';
+import { useReadLocalStorage } from 'usehooks-ts';
+import { deleteFeedComment, patchFeedComment } from '../../../api/mutationfn';
+import { SERVER_URL } from '../../../api/url';
+import { ReactComponent as Write } from '../../../assets/button/write.svg';
+import { BooleanStr } from '../../../types/propType';
 import Profile from '../../profile/Profile';
 import {
   Container,
@@ -5,29 +12,100 @@ import {
   UserId,
   Time,
   Content,
+  EditText,
+  EditTextarea,
+  EditBtn,
 } from './FeedComment.styled';
 
 interface Prop {
-  memberid: number;
+  feedid: number;
+  inperson: BooleanStr;
   nickname: string;
   userimg: string;
   content: string;
+  commentid: number;
+  blankhandler: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function FeedComment({
-  // memberid,
+  feedid,
+  inperson,
   nickname,
   userimg,
   content,
+  commentid,
+  blankhandler,
 }: Prop) {
+  const accessToken = useReadLocalStorage('accessToken');
+  const [isEditOpen, setIsEditOpen] = useState<boolean>(false);
+  const queryClient = useQueryClient();
+
+  const commentEditMuation = useMutation({
+    mutationFn: patchFeedComment,
+    onSuccess: data => {
+      console.log(data);
+      queryClient.invalidateQueries({
+        queryKey: ['feedPopUp', feedid],
+      });
+      setIsEditOpen(false);
+    },
+  });
+
+  const commentDeleteMutation = useMutation({
+    mutationFn: deleteFeedComment,
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: ['feedPopUp', feedid],
+      }),
+  });
+
+  const handleEdit = () => {
+    if (inputRef.current) {
+      if (inputRef.current.value === '') return blankhandler(true);
+      const body = {
+        content: inputRef.current.value,
+        feedId: feedid,
+        url: `${SERVER_URL}/feeds/comments/${commentid}`,
+        token: accessToken as string,
+      };
+      commentEditMuation.mutate(body);
+    }
+  };
+
+  const handleDelete = () => {
+    const body = {
+      url: `${SERVER_URL}/feeds/comments/${commentid}`,
+      accessToken: accessToken as string,
+    };
+    commentDeleteMutation.mutate(body);
+  };
+
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
   return (
     <Container>
       <UserBox>
         <Profile size="sm" isgreen="false" url={userimg} />
         <UserId>{nickname}</UserId>
         <Time>몇시간전</Time>
+        {inperson === 'true' && (
+          <div className="flex gap-2 pl-24">
+            <EditText onClick={() => setIsEditOpen(prev => !prev)}>
+              수정
+            </EditText>
+            <EditText onClick={handleDelete}>삭제</EditText>
+          </div>
+        )}
       </UserBox>
-      <Content>{content}</Content>
+      {!isEditOpen && <Content>{content}</Content>}
+      {isEditOpen && (
+        <div className="relative">
+          <EditTextarea defaultValue={content} ref={inputRef} />
+          <EditBtn onClick={handleEdit}>
+            <Write width={22} />
+          </EditBtn>
+        </div>
+      )}
     </Container>
   );
 }

--- a/client/src/common/header/Header.tsx
+++ b/client/src/common/header/Header.tsx
@@ -31,6 +31,7 @@ export default function Header() {
   const handleClick = () => {
     localStorage.removeItem('accessToken');
     localStorage.removeItem('refreshToken');
+    localStorage.removeItem('animalParents');
     navigate('/');
   };
 

--- a/client/src/common/input/feedInput/FeedInput.styled.tsx
+++ b/client/src/common/input/feedInput/FeedInput.styled.tsx
@@ -12,9 +12,8 @@ export const Input = tw.textarea`
   w-full
   h-10
   rounded-[10px]
-  px-3
+  p-3
   text-xs
-  py-3
   pr-10
 `;
 

--- a/client/src/common/input/feedInput/FeedInput.tsx
+++ b/client/src/common/input/feedInput/FeedInput.tsx
@@ -8,9 +8,10 @@ import { Container, Input, CommentBtn } from './FeedInput.styled';
 
 interface Prop {
   feedid: number;
+  blankhandler: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
-export default function FeedInput({ feedid }: Prop) {
+export default function FeedInput({ feedid, blankhandler }: Prop) {
   const accessToken = useReadLocalStorage('accessToken');
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const queryClient = useQueryClient();
@@ -25,7 +26,7 @@ export default function FeedInput({ feedid }: Prop) {
 
   const handleClick = () => {
     if (inputRef.current) {
-      if (inputRef.current.value === '') return alert('공백안된다');
+      if (inputRef.current.value === '') return blankhandler(true);
       const data = {
         url: `${SERVER_URL}/feeds/comments`,
         token: accessToken as string,

--- a/client/src/components/card/sidenav/SideNav.tsx
+++ b/client/src/components/card/sidenav/SideNav.tsx
@@ -4,6 +4,8 @@ import { useReadLocalStorage } from 'usehooks-ts';
 import { patchFeedLike } from '../../../api/mutationfn';
 import { SERVER_URL } from '../../../api/url';
 import { ReactComponent as Comment } from '../../../assets/button/comment.svg';
+import { ReactComponent as Delete } from '../../../assets/button/delete.svg';
+import { ReactComponent as Edit } from '../../../assets/button/edit.svg';
 import { ReactComponent as Like } from '../../../assets/button/like.svg';
 import { ReactComponent as Share } from '../../../assets/button/share.svg';
 import { BooleanStr } from '../../../types/propType';
@@ -16,7 +18,9 @@ interface Prop {
   like: BooleanStr;
   guesthandler?: () => void;
   toasthandler?: React.Dispatch<React.SetStateAction<boolean>>;
+  deletehandler?: React.Dispatch<React.SetStateAction<boolean>>;
   url: string;
+  inperson?: BooleanStr;
 }
 
 export default function SideNav({
@@ -26,12 +30,15 @@ export default function SideNav({
   like,
   guesthandler,
   toasthandler,
+  deletehandler,
+  inperson,
   url,
 }: Prop) {
   const accessToken = useReadLocalStorage<string | null>('accessToken');
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const feedPopUp = useMatch('/home/:feedId');
+  // console.log(memberId);
 
   const likeMutation = useMutation({
     mutationFn: patchFeedLike,
@@ -100,22 +107,22 @@ export default function SideNav({
           <Share className="cursor-pointer ml-2" />
         </Wrap>
 
-        {/* {inperson === 'true' && (
+        {inperson === 'true' && (
           <>
-            <Wrap onClick={() => navigate(`/feed-posting/${feedid}`)}>
-              <Edit className="cursor-pointer ml-2" />
+            <Wrap
+              onClick={() => navigate(`/feed-posting/${feedid}`)}
+              className="cursor-pointer ml-2">
+              <Edit />
             </Wrap>
-            <Wrap>
-              <Delete
-                className="cursor-pointer ml-2"
-                onClick={() => {
-                  deletehandler();
-                  localStorage.setItem('feedId', String(feedid));
-                }}
-              />
+            <Wrap
+              className="cursor-pointer ml-2"
+              onClick={() => {
+                if (deletehandler) return deletehandler(true);
+              }}>
+              <Delete />
             </Wrap>
           </>
-        )} */}
+        )}
       </Container>
     </>
   );

--- a/client/src/pages/feedPopUp/FeedPopUp.tsx
+++ b/client/src/pages/feedPopUp/FeedPopUp.tsx
@@ -1,16 +1,19 @@
-import { useQuery } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useContext, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
+import { deleteFeed } from '../../api/mutationfn';
 import { getServerDataWithJwt } from '../../api/queryfn';
 import { SERVER_URL } from '../../api/url';
 import { ReactComponent as Close } from '../../assets/button/close.svg';
 import FeedComment from '../../common/comment/feedComment.tsx/FeedComment';
 import FeedInput from '../../common/input/feedInput/FeedInput';
+import Popup from '../../common/popup/Popup';
 import FeedCard from '../../components/card/feedcard/FeedCard';
 import SideNav from '../../components/card/sidenav/SideNav';
 import LoadingComponent from '../../components/loading/LoadingComponent';
 import Toast from '../../components/toast/Toast';
+import { MemberIdContext } from '../../store/Context';
 import { Feed } from '../../types/feedTypes';
 import {
   Container,
@@ -22,9 +25,15 @@ import {
 
 export function Component() {
   const accessToken = useReadLocalStorage('accessToken');
+  const memberId = useContext(MemberIdContext);
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { feedId } = useParams();
   const [isToastOpen, setIsToastOpen] = useState<boolean>(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState<boolean>(false);
+
+  console.log(memberId);
+  // 피드 게시물 정보 가져오기
   const { data, isSuccess, isLoading } = useQuery<Feed>({
     queryKey: ['feedPopUp', Number(feedId)],
     queryFn: () =>
@@ -33,7 +42,28 @@ export function Component() {
         accessToken as string,
       ),
   });
+
   console.log(data);
+
+  const deleteFeedMutation = useMutation({
+    mutationFn: deleteFeed,
+    onSuccess: data => {
+      console.log(data);
+      navigate(-1);
+      queryClient.invalidateQueries({ queryKey: ['guestFeed'] });
+    },
+    // enabled: !!(Number(memberId) === data?.memberInfo.memberId),
+  });
+
+  const handlerDelete = () => {
+    if (data) {
+      const body = {
+        url: `${SERVER_URL}/feeds/${data.feedId}`,
+        token: accessToken as string,
+      };
+      deleteFeedMutation.mutate(body);
+    }
+  };
 
   // ESC 버튼 누를 시, 이전페이지로 이동
   useEffect(() => {
@@ -49,53 +79,74 @@ export function Component() {
   if (isLoading) return <LoadingComponent />;
   if (isSuccess)
     return (
-      <Container
-        onClick={e => {
-          if (e.target === e.currentTarget) navigate(-1);
-        }}>
-        {isToastOpen && (
-          <div className="fixed right-8 bottom-8">
-            <Toast />
-          </div>
-        )}
-        <CloseBtn onClick={() => navigate(-1)}>
-          <Close fill="white" />
-        </CloseBtn>
-        <FeedContainer>
-          <FeedCard
-            memberid={data.memberInfo.memberId}
-            username={data.memberInfo.nickname}
-            context={data.content}
-            userimg={data.memberInfo.imageURL}
-            images={data.images}
+      <>
+        {isDeleteOpen && (
+          <Popup
+            title="피드를 삭제할까요?"
+            isgreen={['true']}
+            btnsize={['md', 'md']}
+            buttontext={['삭제할래요', '아니요']}
+            countbtn={2}
+            handler={[handlerDelete, () => setIsDeleteOpen(false)]}
+            popupcontrol={() => {
+              setIsDeleteOpen(false);
+            }}
           />
-
-          <RightBox>
-            <CommentBox>
-              {data.feedComments !== null &&
-                Array.isArray(data.feedComments) &&
-                data.feedComments.map(comment => (
-                  <FeedComment
-                    key={comment.feedCommentsId}
-                    memberid={comment.memberInfo.memberId}
-                    nickname={comment.memberInfo.nickname}
-                    userimg={comment.memberInfo.imageURL}
-                    content={comment.content}
-                  />
-                ))}
-            </CommentBox>
-            <SideNav
-              feedid={data.feedId}
-              direction="row"
-              likes={data.likes}
-              like={data.isLike ? 'true' : 'false'}
-              url={data.shareURL}
-              toasthandler={setIsToastOpen}
+        )}
+        <Container
+          onClick={e => {
+            if (e.target === e.currentTarget) navigate(-1);
+          }}>
+          {isToastOpen && (
+            <div className="fixed right-8 bottom-8">
+              <Toast />
+            </div>
+          )}
+          <CloseBtn onClick={() => navigate(-1)}>
+            <Close fill="white" />
+          </CloseBtn>
+          <FeedContainer>
+            <FeedCard
+              memberid={data.memberInfo.memberId}
+              username={data.memberInfo.nickname}
+              context={data.content}
+              userimg={data.memberInfo.imageURL}
+              images={data.images}
             />
-            <FeedInput feedid={data.feedId} />
-          </RightBox>
-        </FeedContainer>
-      </Container>
+
+            <RightBox>
+              <CommentBox>
+                {data.feedComments !== null &&
+                  Array.isArray(data.feedComments) &&
+                  data.feedComments.map(comment => (
+                    <FeedComment
+                      key={comment.feedCommentsId}
+                      memberid={comment.memberInfo.memberId}
+                      nickname={comment.memberInfo.nickname}
+                      userimg={comment.memberInfo.imageURL}
+                      content={comment.content}
+                    />
+                  ))}
+              </CommentBox>
+              <SideNav
+                feedid={data.feedId}
+                direction="row"
+                likes={data.likes}
+                like={data.isLike ? 'true' : 'false'}
+                url={data.shareURL}
+                toasthandler={setIsToastOpen}
+                deletehandler={setIsDeleteOpen}
+                inperson={
+                  Number(memberId) === data.memberInfo.memberId
+                    ? 'true'
+                    : 'false'
+                }
+              />
+              <FeedInput feedid={data.feedId} />
+            </RightBox>
+          </FeedContainer>
+        </Container>
+      </>
     );
 }
 

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -17,6 +17,7 @@ import { Feed } from '../../types/feedTypes';
 import { Container, FollowContainer, Img, Text, Button } from './Home.styled';
 
 export function Component() {
+  const queryClient = useQueryClient();
   const accessToken = useReadLocalStorage<string>('accessToken');
   const [isClicked, setIsClicked] = useState<boolean>(false);
   const [isToastOpen, setIsToastOpen] = useState<boolean>(false);

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -23,7 +23,6 @@ export function Component() {
   const [isToastOpen, setIsToastOpen] = useState<boolean>(false);
   const [isGuestOpen, setIsGuestOpen] = useState<boolean>(false);
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
 
   const guestFeedQuery = useQuery({
     queryKey: ['guestFeed'],

--- a/client/src/pages/loading/Loading.tsx
+++ b/client/src/pages/loading/Loading.tsx
@@ -13,7 +13,6 @@ export function Component() {
     '',
   );
 
-  console.log(searchParams.get('accessToken'));
   // local에 accessToken이 있는지 확인하기
   const dispatch = useContext(MemberIdDispatchContext);
 


### PR DESCRIPTION
### What is this PR?

- 피드 게시물 댓글 수정 및 삭제 구현 완료하였습니다.
- 이슈 close
    - close #39 

### TODO
## Feed
- [x] 피드 게시물은 피드 페이지의 피드와 추가로 댓글을 보여줍니다. 
- [ ] 피드 게시물의 유저 네임 혹은 유저 프로필을 클릭하면 유저 페이지로 이동합니다.

## Comment
- [ ] 댓글은 한번에 10개를 보여주며, 무한 스크롤로 구현합니다.(초기 팝업 페이지 생성시 모든 댓글을 가지고 옵니다.)
- [ ] 댓글은 유저 프로필, 유저 닉네임, 댓글 내용, 생성 시간으로 구성됩니다.
- [ ] 댓글의 유저 프로필, 유저 닉네임을 클릭하면 해당 유저페이지로 이동합니다.
- [x] 본인이 작성한 댓글에는 수정과 삭제 버튼을 볼 수 있습니다. 
- [x] 댓글 수정시 인풋 창이 생성됩니다. 
- [x] 수정과 삭제는 본인이 작성한 게시물일 경우 해당 팝업 페이지에서 언제든 가능합니다.
- [x] 유저가 계정이 없는 경우 댓글 작성 input을 비활성화 합니다.

## Button
- [x] 공통 button은 좋아요, 댓글, 링크 복사 버튼입니다.
- [x] 게시글 작성자와 유저가 일치할시 추가로 게시글 수정 버튼과 게시글 삭제 버튼을 보여줍니다.
- [x] #49
- [x] 게시글 삭제 버튼 클릭시 삭제를 확인하는 팝업창을 띄우고 삭제를 진행합니다. 
- [x] 본인이 좋아요를 이미 클릭한 게시물일 경우 이를 표기해야 합니다. 
- [x] 좋아요  button 아래에는 좋아요 총 개수가 표시되어야 합니다.

## 팝업 페이지 클립보드
- [ ] 피드페이지, 팝업 페이지에서 링크공유로 복사된 url은 팝업을 구분하는 쿼리 파람이 포함되어야 합니다.
(ex. http:/copy/:feedId)
- [x] 팝업 이외에 페이지 형식은 같습니다. 
- [x] 비로그인 유저는 오직 홈으로만 이동할 수 있습니다.  
- [x] header의 홈 버튼은 비활성화 되어 있어야 합니다.



### Screenshot



https://github.com/codestates-seb/seb44_main_018/assets/82816029/f0de77bb-c336-4bfe-86eb-306844e64b79

