### PR TITLE
Fix: Select 컴포넌트의 주소 수정

### DIFF
--- a/client/src/api/queryfn.ts
+++ b/client/src/api/queryfn.ts
@@ -1,21 +1,12 @@
-import axios, { isAxiosError } from 'axios';
+import axios from 'axios';
 import { ZIP_URL } from './url';
 
 // 쿼리함수를 관리합니다.
 
 //시군구 정보 가져오기
 export const getLocal = async (pattern: string) => {
-  try {
-    const result = await axios.get(`${ZIP_URL}${pattern}`);
-    return result.data;
-  } catch (error) {
-    if (isAxiosError(error)) {
-      const errMessage = error.message;
-      return errMessage;
-    } else {
-      return error;
-    }
-  }
+  const result = await axios.get(`${ZIP_URL}${pattern}`);
+  return result.data;
 };
 
 /* -------------------------------- 서버에서 데이터 가지고 오기 ------------------------------- */

--- a/client/src/common/select/Select.tsx
+++ b/client/src/common/select/Select.tsx
@@ -14,6 +14,25 @@ interface Prop {
 
 const BASE_PATTERN = '*00000000';
 
+const BASE_CODE: { [key: string]: string } = {
+  서울특별시: '서울',
+  부산광역시: '부산',
+  대구광역시: '대구',
+  인천광역시: '인천',
+  광주광역시: '광주',
+  대전광역시: '대전',
+  울산광역시: '울산',
+  경기도: '경기',
+  충청북도: '충북',
+  충청남도: '충남',
+  전라북도: '전북',
+  전라남도: '전남',
+  경상북도: '경북',
+  경상남도: '경남',
+  제주특별자치도: '제주특별자치도',
+  강원특별자치도: '강원특별자치도',
+};
+
 export default function SelectComponent({ size, direction, setZip }: Prop) {
   //state
   const [countryCode, setCountryCode] = useState<undefined | string>(undefined);
@@ -26,7 +45,6 @@ export default function SelectComponent({ size, direction, setZip }: Prop) {
   const zipRef = useRef('');
   //  주소 저장
   zipRef.current = `${zipNameCountry} ${zipNameCity} ${zipNameVillage}`;
-
   // hook 사용하기
   const { data: counrtyData, isLoading: countryLoading } = useQuery<getData>({
     queryKey: ['country'],
@@ -49,7 +67,7 @@ export default function SelectComponent({ size, direction, setZip }: Prop) {
   useEffect(() => {
     if (!countryLoading) {
       setCountryCode(changeCountryCode(cityData?.regcodes[0].code as string));
-      setZipNameCountry('서울특별시');
+      setZipNameCountry(BASE_CODE.서울특별시);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [countryLoading]);
@@ -70,7 +88,7 @@ export default function SelectComponent({ size, direction, setZip }: Prop) {
           const valueArr = e.target.value.split(' ');
           setCountryCode(changeCountryCode(valueArr[0]));
           setCityCode('');
-          setZipNameCountry(valueArr[1]);
+          setZipNameCountry(BASE_CODE[valueArr[1]]);
           setZipNameCity('');
           setZipNameVillage('');
         }}>

--- a/client/src/pages/walkPosting/WalkPosting.tsx
+++ b/client/src/pages/walkPosting/WalkPosting.tsx
@@ -136,7 +136,6 @@ export function Component() {
               type="text"
               readOnly
               value={`${mainAddress} ${detailAddress}`}
-              onClick={() => console.log('his')}
               {...register('location', {
                 required: '장소를 선택해주세요!',
                 value: `${mainAddress}`,


### PR DESCRIPTION
What is this PR?
- 카카오맵과 주소 형식을 일치하기 위해 state에 저장하는 주소 값을 변경했습니다.
- 변경된 주소는 다음과 같습니다.
```typescript
const BASE_CODE: { [key: string]: string } = {
  서울특별시: '서울',
  부산광역시: '부산',
  대구광역시: '대구',
  인천광역시: '인천',
  광주광역시: '광주',
  대전광역시: '대전',
  울산광역시: '울산',
  경기도: '경기',
  충청북도: '충북',
  충청남도: '충남',
  전라북도: '전북',
  전라남도: '전남',
  경상북도: '경북',
  경상남도: '경남',
  제주특별자치도: '제주특별자치도',
  강원특별자치도: '강원특별자치도',
};
```
- Close #123 

Todo