### PR TITLE
Feat: 피드 게시물 수정 기능 구현 완료

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ function App() {
   const matchInfoEditing = useMatch('/info/:userId'); //object || null
   const matchFeed = useMatch('/home');
   const matchFeedPosting = useMatch('/feed-posting');
+  const matchFeedEditing = useMatch('/feed-posting/:feedId');
   const loadingFeed = useMatch('/loading');
 
   return (
@@ -19,7 +20,8 @@ function App() {
         matchInfoEditing ||
         matchFeedPosting ||
         loadingFeed ||
-        matchFeedPopUp
+        matchFeedPopUp ||
+        matchFeedEditing
       ) && <Header />}
       <Outlet />
       {!(
@@ -28,7 +30,8 @@ function App() {
         matchFeed ||
         matchInfoEditing ||
         matchFeedPosting ||
-        matchFeedPopUp
+        matchFeedPopUp ||
+        matchFeedEditing
       ) && <Footer />}
     </>
   );

--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -165,7 +165,7 @@ interface FeedPostingProp {
   accessToken: string | null;
   formData: FormData;
 }
-export const feedPosting = async (body: FeedPostingProp) => {
+export const postFeed = async (body: FeedPostingProp) => {
   const { url, accessToken, formData } = body;
   const result = await axios.post(url, formData, {
     headers: {
@@ -174,6 +174,19 @@ export const feedPosting = async (body: FeedPostingProp) => {
     },
   });
   return result.data;
+};
+
+/* -------------------------------- 피드게시물 수정 -------------------------------- */
+
+export const patchFeed = async (body: FeedPostingProp) => {
+  const { url, accessToken, formData } = body;
+  const result = await axios.patch(url, formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      Authorization: accessToken,
+    },
+  });
+  return result;
 };
 
 /* -------------------------------- 피드게시물 삭제 -------------------------------- */

--- a/client/src/common/comment/feedComment.tsx/FeedComment.styled.tsx
+++ b/client/src/common/comment/feedComment.tsx/FeedComment.styled.tsx
@@ -8,18 +8,19 @@ export const UserBox = tw.div`
   flex
   items-center
   gap-2
+  cursor-pointer
 `;
 
 export const UserId = tw.span`
   font-black
   text-defaulttext
   text-xs
-  
 `;
 
 export const Time = tw.span`
   text-deepgray
   text-xs
+  cursor-default
 `;
 
 export const Content = tw.span`

--- a/client/src/common/comment/feedComment.tsx/FeedComment.tsx
+++ b/client/src/common/comment/feedComment.tsx/FeedComment.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useReadLocalStorage } from 'usehooks-ts';
 import { deleteFeedComment, patchFeedComment } from '../../../api/mutationfn';
 import { SERVER_URL } from '../../../api/url';
@@ -25,6 +26,7 @@ interface Prop {
   content: string;
   commentid: number;
   blankhandler: React.Dispatch<React.SetStateAction<boolean>>;
+  memberid: number;
 }
 
 export default function FeedComment({
@@ -35,15 +37,16 @@ export default function FeedComment({
   content,
   commentid,
   blankhandler,
+  memberid,
 }: Prop) {
+  const navigate = useNavigate();
   const accessToken = useReadLocalStorage('accessToken');
   const [isEditOpen, setIsEditOpen] = useState<boolean>(false);
   const queryClient = useQueryClient();
 
   const commentEditMuation = useMutation({
     mutationFn: patchFeedComment,
-    onSuccess: data => {
-      console.log(data);
+    onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['feedPopUp', feedid],
       });
@@ -84,7 +87,7 @@ export default function FeedComment({
 
   return (
     <Container>
-      <UserBox>
+      <UserBox onClick={() => navigate(`/users/${memberid}`)}>
         <Profile size="sm" isgreen="false" url={userimg} />
         <UserId>{nickname}</UserId>
         <Time>몇시간전</Time>

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -1,15 +1,17 @@
-import { useMutation } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useCallback, useRef, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import { Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { useReadLocalStorage } from 'usehooks-ts';
-import { feedPosting } from '../../../api/mutationfn';
+import { patchFeed, postFeed } from '../../../api/mutationfn';
+import { getServerDataWithJwt } from '../../../api/queryfn';
 import { SERVER_URL } from '../../../api/url';
 import { ReactComponent as Close } from '../../../assets/button/close.svg';
 import { ReactComponent as Plus } from '../../../assets/button/plus.svg';
 import { ReactComponent as Write } from '../../../assets/button/write.svg';
 import Popup from '../../../common/popup/Popup';
+import { FeedImage, Feed } from '../../../types/feedTypes';
 import { parseImg, deleteImg } from '../../../util/parseImg';
 import LoadingComponent from '../../loading/LoadingComponent';
 import {
@@ -27,15 +29,19 @@ import 'swiper/css/navigation';
 import '../../../common/carousel/carousel.css';
 
 export default function FeedWriteCard() {
+  const queryClient = useQueryClient();
+  const { feedId } = useParams();
   const navigate = useNavigate();
   const textRef = useRef<HTMLTextAreaElement>(null);
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [removedFile, setRemovedFile] = useState<string[]>([]);
   const [savedFile, setSavedFile] = useState<string[]>([]);
-  const [prevFile, setPrevFile] = useState<File[]>([]);
+  const [prevFile, setPrevFile] = useState<(File | FeedImage)[]>([]);
 
   /* ----------------------------- useLocalStorage ---------------------------- */
   const accessToken = useReadLocalStorage<string>('accessToken');
 
+  // esc 누를 시, 창닫기
   useEffect(() => {
     const getBackPage = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -46,23 +52,71 @@ export default function FeedWriteCard() {
     return () => window.removeEventListener('keydown', getBackPage);
   }, [navigate]);
 
-  const { mutate, isLoading } = useMutation({
-    mutationFn: feedPosting,
+  // param이 있을 경우,  피드 게시물 정보 가져오기
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const getFeedDetailQuery = useQuery<Feed>({
+    queryKey: ['feedPopUp', Number(feedId)],
+    queryFn: async () => {
+      const result = await getServerDataWithJwt(
+        `${SERVER_URL}/feeds/${feedId}`,
+        accessToken as string,
+      );
+      result.images.map((image: FeedImage) => {
+        setSavedFile(prev => [...prev, image.uploadFileURL]);
+        setPrevFile(prev => [...prev, image]);
+      });
+      if (textRef.current) {
+        textRef.current.value = result.content;
+      }
+      return result;
+    },
+    enabled: !!feedId && savedFile.length === 0,
+  });
+
+  // 피드 게시물 올리기 mutation
+  const feedPostingMutation = useMutation({
+    mutationFn: postFeed,
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myPage'] });
+      queryClient.invalidateQueries({ queryKey: ['myFeed'] });
+      queryClient.invalidateQueries({ queryKey: ['followList'] });
       navigate('/my-page');
+    },
+  });
+
+  // 피드 게시물 수정하기 mutation
+  const feedEditingMutation = useMutation({
+    mutationFn: patchFeed,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['feedPopUp'] });
+      navigate(`/home/${feedId}`);
     },
   });
 
   const handleSubmit = () => {
     const formData = new FormData();
     formData.append('content', textRef.current?.value as string);
-    prevFile.forEach(file => formData.append('images', file));
-    const data = {
-      url: `${SERVER_URL}/feeds`,
-      accessToken,
-      formData,
-    };
-    mutate(data);
+    if (feedId === undefined) {
+      prevFile.forEach(file => formData.append('images', file as File));
+      const data = {
+        url: `${SERVER_URL}/feeds`,
+        accessToken,
+        formData,
+      };
+      feedPostingMutation.mutate(data);
+    } else {
+      prevFile.forEach(file => formData.append('addImage', file as File));
+      if (removedFile.length > 0)
+        removedFile.forEach(fileName =>
+          formData.append('deleteImage', fileName as string),
+        );
+      const data = {
+        url: `${SERVER_URL}/feeds/${feedId}`,
+        accessToken,
+        formData,
+      };
+      feedEditingMutation.mutate(data);
+    }
   };
 
   const handleUpload = useCallback(
@@ -74,11 +128,18 @@ export default function FeedWriteCard() {
 
   const handleSemiClose = useCallback(
     (order: number) =>
-      deleteImg({ order, savedFile, setSavedFile, setPrevFile, prevFile }),
+      deleteImg({
+        order,
+        savedFile,
+        setSavedFile,
+        setPrevFile,
+        prevFile,
+        setRemovedFile,
+      }),
     [savedFile, prevFile],
   );
 
-  if (isLoading) {
+  if (feedPostingMutation.isLoading) {
     return <LoadingComponent />;
   }
 

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -10,12 +10,10 @@ import ContextProvider from './store/Context.tsx';
 const queryClient = new QueryClient();
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ContextProvider>
-        <RouterProvider router={router} />
-        <ReactQueryDevtools initialIsOpen={false} />
-      </ContextProvider>
-    </QueryClientProvider>
-  </React.StrictMode>,
+  <QueryClientProvider client={queryClient}>
+    <ContextProvider>
+      <RouterProvider router={router} />
+      <ReactQueryDevtools initialIsOpen={false} />
+    </ContextProvider>
+  </QueryClientProvider>,
 );

--- a/client/src/pages/feedEditing/FeedEditing.tsx
+++ b/client/src/pages/feedEditing/FeedEditing.tsx
@@ -1,5 +1,0 @@
-export function Component() {
-  return <div>FeedEditing</div>;
-}
-
-Component.displayName = 'FeedEditing';

--- a/client/src/pages/feedPopUp/FeedPopUp.tsx
+++ b/client/src/pages/feedPopUp/FeedPopUp.tsx
@@ -157,6 +157,7 @@ export function Component() {
                       commentid={comment.feedCommentsId}
                       feedid={data.feedId}
                       blankhandler={setIsBlank}
+                      memberid={comment.memberInfo.memberId}
                     />
                   ))}
               </CommentBox>

--- a/client/src/pages/myPage/MyPage.tsx
+++ b/client/src/pages/myPage/MyPage.tsx
@@ -267,7 +267,11 @@ export function Component() {
                           <Link to={`/home/${item.feedId}`} key={item.feedId}>
                             <img
                               className="w-full h-[180px] rounded-[28px] object-cover border-2 hover:drop-shadow-lg"
-                              src={item.images[0].uploadFileURL}
+                              src={
+                                item.images[0]
+                                  ? item.images[0].uploadFileURL
+                                  : ''
+                              }
                             />
                           </Link>
                         ))}

--- a/client/src/routers/routers.tsx
+++ b/client/src/routers/routers.tsx
@@ -48,7 +48,7 @@ export const router = createBrowserRouter([
       },
       {
         path: Path.FeedEditing,
-        lazy: () => import('../pages/feedEditing/FeedEditing'),
+        lazy: () => import('../pages/feedPosting/FeedPosting'),
       },
       {
         path: Path.WalkMate,

--- a/client/src/util/parseImg.ts
+++ b/client/src/util/parseImg.ts
@@ -1,8 +1,10 @@
+import { FeedImage } from '../types/feedTypes';
+
 interface ParseImgProp {
   e: React.ChangeEvent<HTMLInputElement>;
   setSavedFile: React.Dispatch<React.SetStateAction<string[]>>;
   setIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-  setPrevFile: React.Dispatch<React.SetStateAction<File[]>>;
+  setPrevFile: React.Dispatch<React.SetStateAction<(File | FeedImage)[]>>;
   savedFile: string[];
 }
 
@@ -31,7 +33,10 @@ export const parseImg = ({
     const readAndPreview = (file: File) => {
       if (/\.(jpe?g|png)$/i.test(file.name)) {
         const reader = new FileReader();
-        setPrevFile(prev => [...prev, file]);
+        setPrevFile(prev => {
+          console.log(prev);
+          return [...prev, file];
+        });
         reader.readAsDataURL(file);
         return new Promise<void>(resolve => {
           reader.onload = () => {
@@ -51,8 +56,9 @@ interface DeleteImgProp {
   setSavedFile: React.Dispatch<React.SetStateAction<string[]>>;
   savedFile: string[];
   order: number;
-  setPrevFile: React.Dispatch<React.SetStateAction<File[]>>;
-  prevFile: File[];
+  setPrevFile: React.Dispatch<React.SetStateAction<(File | FeedImage)[]>>;
+  prevFile: (File | FeedImage)[];
+  setRemovedFile: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
 export const deleteImg = ({
@@ -61,11 +67,17 @@ export const deleteImg = ({
   order,
   setPrevFile,
   prevFile,
+  setRemovedFile,
 }: DeleteImgProp) => {
   let preCopy = prevFile;
+  if ('originalFilename' in preCopy[order]) {
+    const removeFile = preCopy[order] as FeedImage;
+    setRemovedFile(prev => [...prev, removeFile.originalFilename]);
+  }
   preCopy = preCopy.filter((_, idx) => idx !== order);
   let copy = savedFile;
   copy = copy.filter((_, idx) => idx !== order);
+
   setPrevFile(preCopy);
   setSavedFile(copy);
 };


### PR DESCRIPTION
### What is this PR?
- 피드 게시물 수정 기능 구현 완료하였습니다.
- 피드 게시물 댓글에 달린 유저를 클릭하면 그 유저페이지로 이동하게 수정하였습니다.

- 이슈 close
    - close #42 

### TODO
- [x] 자신이 작성한 피드 게시물에 수정버튼을 누르면 `feed-posting/:feedId`로 이동되게한다.
- [x] 자신이 작성한 피드 게시물에 수정버튼을 누르면 게시물 수정 팝업이 뜨게 한다.
- [x] `/{feed-id}`로 GET요청 하여 게시물의 정보를 가져와 게시물의 사진과 내용 데이터를 미리 채워놓는다.
- [x] 게시물 사진은 캐러셀 형태로 이뤄져야하며, 최대 3개만 이미지가 등록가능하다.
- [x] 이미지 상단에 `'X'` 버튼을 누르면 이미지가 캐러셀에서 삭제되게한다.
- [x] `'X'`버튼을 누르면 삭제할 이미지 리스트로 담아두어야한다. (요청으로 보내기위해)
- [x] 이미지를 추가하면 추가할 이미지 데이터 리스트로 담아두어야한다.
- [x] 수정버튼을 누르면 `/{feed-id}/{member-id}`로 POST요청을 보낸다.
  - POST요청시, request body는 API명세서를 참고한다. (이슈 작성시, 명세서 수정중임)

### Screenshot
https://github.com/codestates-seb/seb44_main_018/assets/82816029/e1daf3b2-c609-4ac4-911a-e222e176c644
눈물겨운 구현 . . 제일 하기 싫었던 작업이었으나 모두 완료했군요 . .