### PR TITLE
Remove: 피드 포스트 팝업 엔터 submit 삭제

### DIFF
--- a/client/src/api/mutationfn.ts
+++ b/client/src/api/mutationfn.ts
@@ -247,7 +247,6 @@ export const postFeedComment = async (body: PostFeedCommentProp) => {
 /* -------------------------------- 피드게시물 댓글 수정  -------------------------------- */
 export const patchFeedComment = async (body: PostFeedCommentProp) => {
   const { url, token, content, feedId } = body;
-  console.log(body);
   const result = await axios.patch(
     url,
     { content, feedId },
@@ -393,7 +392,6 @@ interface PostQuitMemberProp {
 }
 
 export const postQuitMember = async (payload: PostQuitMemberProp) => {
-  console.log(`${SERVER_URL}/auth/kakao/unlink`);
   const { accessToken } = payload;
 
   const result = await axios.delete(`${SERVER_URL}/auth/kakao/unlink`, {

--- a/client/src/common/comment/feedComment.tsx/FeedComment.tsx
+++ b/client/src/common/comment/feedComment.tsx/FeedComment.tsx
@@ -77,6 +77,10 @@ export default function FeedComment({
     }
   };
 
+  const handleSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') handleEdit();
+  };
+
   const handleDelete = () => {
     const body = {
       url: `${SERVER_URL}/feeds/comments/${commentid}`,
@@ -111,7 +115,11 @@ export default function FeedComment({
       {!isEditOpen && <Content>{content}</Content>}
       {isEditOpen && (
         <div className="relative">
-          <EditInput defaultValue={content} ref={inputRef} />
+          <EditInput
+            defaultValue={content}
+            ref={inputRef}
+            onKeyUp={e => handleSubmit(e)}
+          />
           <EditBtn onClick={handleEdit}>
             <Write width={22} />
           </EditBtn>

--- a/client/src/common/input/feedInput/FeedInput.tsx
+++ b/client/src/common/input/feedInput/FeedInput.tsx
@@ -38,9 +38,20 @@ export default function FeedInput({ feedid, blankhandler }: Prop) {
     }
   };
 
+  const handleSubmit = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      if (inputRef.current?.value !== '') handleClick();
+    }
+  };
+
   return (
     <Container>
-      <Input ref={inputRef} type="text" />
+      <Input
+        ref={inputRef}
+        type="text"
+        onKeyUp={e => handleSubmit(e)}
+        placeholder="댓글을 입력해주세요."
+      />
       <CommentBtn onClick={handleClick}>
         <Write />
       </CommentBtn>

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -136,10 +136,6 @@ export default function FeedWriteCard() {
     [savedFile],
   );
 
-  const handleEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (e.key === 'Enter') handleSubmit();
-  };
-
   const handleSemiClose = useCallback(
     (order: number) =>
       deleteImg({
@@ -244,7 +240,6 @@ export default function FeedWriteCard() {
             placeholder="글을 입력해주세요."
             maxLength={200}
             ref={textRef}
-            onKeyUp={e => handleEnter(e)}
           />
           <SubmitBtn type="button" onClick={handleSubmit}>
             <Write />

--- a/client/src/components/card/feedwritecard/FeedWriteCard.tsx
+++ b/client/src/components/card/feedwritecard/FeedWriteCard.tsx
@@ -103,10 +103,10 @@ export default function FeedWriteCard() {
   });
 
   const handleSubmit = () => {
+    if (prevFile.length === 0) return setIsNoneOpen(true);
     const formData = new FormData();
     formData.append('content', textRef.current?.value as string);
     if (feedId === undefined) {
-      if (prevFile.length === 0) return setIsNoneOpen(true);
       prevFile.forEach(file => formData.append('images', file as File));
       const data = {
         url: `${SERVER_URL}/feeds`,
@@ -115,7 +115,6 @@ export default function FeedWriteCard() {
       };
       feedPostingMutation.mutate(data);
     } else {
-      if (prevFile.length === 0) return setIsNoneOpen(true);
       prevFile.forEach(file => formData.append('addImage', file as File));
       if (removedFile.length > 0)
         removedFile.forEach(fileName =>
@@ -136,6 +135,10 @@ export default function FeedWriteCard() {
     },
     [savedFile],
   );
+
+  const handleEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter') handleSubmit();
+  };
 
   const handleSemiClose = useCallback(
     (order: number) =>
@@ -241,6 +244,7 @@ export default function FeedWriteCard() {
             placeholder="글을 입력해주세요."
             maxLength={200}
             ref={textRef}
+            onKeyUp={e => handleEnter(e)}
           />
           <SubmitBtn type="button" onClick={handleSubmit}>
             <Write />

--- a/client/src/pages/feedPopUp/FeedPopUp.tsx
+++ b/client/src/pages/feedPopUp/FeedPopUp.tsx
@@ -116,7 +116,7 @@ export function Component() {
             <CommentClose onClick={() => setIsCommentOpen(false)}>
               <Close fill="white" />
             </CommentClose>
-            <div className="bg-white/75 w-[320px] h-[482px] rounded-3xl p-3">
+            <div className="bg-white/95 w-[320px] h-[482px] rounded-3xl p-3">
               <CommentBox>
                 {data.feedComments !== null &&
                   Array.isArray(data.feedComments) &&
@@ -148,7 +148,7 @@ export function Component() {
             if (e.target === e.currentTarget) navigate(-1);
           }}>
           {isToastOpen && (
-            <div className="fixed right-3 bottom-4">
+            <div className="fixed right-3 bottom-4 z-50">
               <Toast />
             </div>
           )}

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -167,7 +167,12 @@ export function Component() {
           </PopupBackGround>
         )}
         {isToastOpen && (
-          <div className="fixed top-20 right-8">
+          <div
+            className={
+              window.innerWidth < 420
+                ? 'fixed top-5 right-2 z-50'
+                : 'fixed top-28 right-8 z-50'
+            }>
             <Toast />
           </div>
         )}


### PR DESCRIPTION
- 알림 토스트가 z-index가 낮아 보이지 않아 수정하였습니다.
- 피드 팝업창 댓글에서 엔터를 누르면 댓글이 달리도록 수정하였습니다.
- textarea에서 엔터를 치면 글이 발행되게 했던 로직을 삭제하였습니다.
- 사용자 경험에 좋지 않은 것 같다고 판단하여 삭제하였습니다.