### PR TITLE
Test: console.log - searchParams.size

### DIFF
--- a/client/src/pages/loading/Loading.tsx
+++ b/client/src/pages/loading/Loading.tsx
@@ -18,8 +18,10 @@ export function Component() {
   const dispatch = useContext(MemberIdDispatchContext);
 
   useEffect(() => {
-    if (searchParams.size > 0) {
+    console.log(searchParams.size);
+    if (searchParams.size !== 0) {
       console.log(searchParams.size);
+      console.log('0보다 큰게 아니고 0이 아니면으로 하면 들어오나?');
       console.log('=====================');
       const accessTokenValue = searchParams.get('accessToken');
       setAccessToken(accessTokenValue);


### PR DESCRIPTION
- searchParams.size가 뭔지 확인하기 위해 콘솔을 찍어보았습니다. 
- 이전 콘솔을 확인했을 때 `if (searchParams.size !== 0)` 조건문 안에 있는 콘솔들이 찍히지 않는다는 것을 확인했습니다. 